### PR TITLE
Use Get-CimInstance in disk usage script

### DIFF
--- a/scripts/DiskUsageReport.ps1
+++ b/scripts/DiskUsageReport.ps1
@@ -3,7 +3,7 @@
     Generates a disk usage report for local drives.
 #>
 
-Get-WmiObject Win32_LogicalDisk -Filter "DriveType=3" |
+Get-CimInstance -ClassName Win32_LogicalDisk -Filter "DriveType=3" |
     Select-Object DeviceID,
                   @{Name="SizeGB";Expression={[math]::round($_.Size/1GB,2)}},
                   @{Name="FreeGB";Expression={[math]::round($_.FreeSpace/1GB,2)}},


### PR DESCRIPTION
## Summary
- use `Get-CimInstance` instead of deprecated `Get-WmiObject` in DiskUsageReport

## Testing
- `pwsh -Command "& './scripts/DiskUsageReport.ps1'"` *(fails: Get-CimInstance cmdlet not found)*

------
https://chatgpt.com/codex/tasks/task_e_6847e2ec2d388332a339bf980c277f69