### PR TITLE
Add security note on remote script execution

### DIFF
--- a/scripts/setup_api.sh
+++ b/scripts/setup_api.sh
@@ -15,6 +15,12 @@ pip3 install --upgrade pip
 pip3 install flask requests
 
 echo "⬇️ Installation d'Ollama..."
+# WARNING: executing a remote script with curl | bash can be dangerous.
+# Review https://ollama.ai/install.sh or verify its checksum before running.
+# Example:
+#   curl -fsSL https://ollama.ai/install.sh -o install.sh
+#   sha256sum install.sh # compare with the expected value
+#   bash install.sh
 curl -fsSL https://ollama.ai/install.sh | bash
 
 echo "📦 Téléchargement du modèle Mistral..."


### PR DESCRIPTION
## Summary
- add warning about running remote scripts in `setup_api.sh`

## Testing
- `bash -n scripts/setup_api.sh`

------
https://chatgpt.com/codex/tasks/task_e_6870f6f416548332b21a83fe08375c8f