### PR TITLE
Fix LinkCrawler help comment syntax

### DIFF
--- a/scripts/LinkCrawler.ps1
+++ b/scripts/LinkCrawler.ps1
@@ -1,4 +1,4 @@
-<#[
+<#
 .SYNOPSIS
     Crawls a website to verify the status of internal and external links.
 .DESCRIPTION


### PR DESCRIPTION
## Summary
- correct opening delimiter in `LinkCrawler.ps1` help comment

## Testing
- `pwsh` not available, no tests run

------
https://chatgpt.com/codex/tasks/task_e_6870fd9b4e408332b569254f264d83b7