### PR TITLE
Improve privilege checks and fix wifi script

### DIFF
--- a/scripts/ManageServices.ps1
+++ b/scripts/ManageServices.ps1
@@ -25,6 +25,12 @@ param(
     [string]$ServiceName
 )
 
+# Ensure script runs with administrative privileges
+if (-not ([Security.Principal.WindowsPrincipal] [Security.Principal.WindowsIdentity]::GetCurrent()).IsInRole([Security.Principal.WindowsBuiltinRole]::Administrator)) {
+    Write-Error 'This script must be run as Administrator.'
+    return
+}
+
 try {
     $service = Get-Service -Name $ServiceName -ErrorAction Stop
 } catch {

--- a/scripts/UserManagement.ps1
+++ b/scripts/UserManagement.ps1
@@ -28,6 +28,12 @@ param(
     [string]$Password
 )
 
+# Ensure script runs with administrative privileges
+if (-not ([Security.Principal.WindowsPrincipal] [Security.Principal.WindowsIdentity]::GetCurrent()).IsInRole([Security.Principal.WindowsBuiltinRole]::Administrator)) {
+    Write-Error 'This script must be run as Administrator.'
+    return
+}
+
 switch ($Action.ToLower()) {
     'create' {
         if (-not $UserName -or -not $Password) {

--- a/scripts/pentest_verification.sh
+++ b/scripts/pentest_verification.sh
@@ -14,6 +14,14 @@ if [[ ! -d "$RESULTS_DIR" ]]; then
     exit 1
 fi
 
+# Ensure required tools are available
+for cmd in nmap msfconsole; do
+    if ! command -v "$cmd" >/dev/null; then
+        echo "❌ Outil manquant : $cmd" >&2
+        exit 1
+    fi
+done
+
 count=0
 
 for xml in "$RESULTS_DIR"/*_discovery.xml; do

--- a/scripts/scan_wifi.sh
+++ b/scripts/scan_wifi.sh
@@ -82,4 +82,11 @@ echo "[*] Attente du handshake pendant $CAPTURE_TIME s..."
 sleep "$CAPTURE_TIME"
 kill "$AIRDUMP_PID" 2>/dev/null || true
 
-HANDSHAKE_FILE=$(ls "$OUT_
+# Vérifie la présence du fichier de capture
+HANDSHAKE_FILE="$OUTPUT_DIR/${CAP_BASENAME}-01.cap"
+if [[ -f "$HANDSHAKE_FILE" ]]; then
+    echo "✅ Handshake capturé : $HANDSHAKE_FILE"
+else
+    echo "❌ Handshake non trouvé" >&2
+fi
+

--- a/scripts/setup_api.sh
+++ b/scripts/setup_api.sh
@@ -6,6 +6,12 @@ set -euo pipefail
 # Variables
 APP_PATH="$HOME/mistral_api.py"
 
+# Require root privileges for package installation
+if [[ $EUID -ne 0 ]]; then
+    echo "❌ Ce script doit être exécuté en tant que root" >&2
+    exit 1
+fi
+
 echo "🔧 Mise à jour des paquets et installation des dépendances..."
 sudo apt-get update
 sudo apt-get install -y python3 python3-pip curl


### PR DESCRIPTION
## Summary
- add admin privilege verification to service and user management scripts
- require root when setting up API environment
- check required tools before running pentest verification
- complete wifi handshake capture script

## Testing
- `bash -n scripts/scan_wifi.sh`
- `bash -n scripts/pentest_verification.sh`
- `bash -n scripts/pentest_discovery.sh`
- `bash -n scripts/pentest_exploitation.sh`
- `bash -n scripts/setup_api.sh`
- `bash -n scripts/stealth_post.sh`


------
https://chatgpt.com/codex/tasks/task_e_688b50e14dbc83328283ae839e780f08