### PR TITLE
Add optional system details export to Get-SystemInfo

### DIFF
--- a/scripts/powershell/Get-SystemInfo.ps1
+++ b/scripts/powershell/Get-SystemInfo.ps1
@@ -1,12 +1,79 @@
 <#
 .SYNOPSIS
-    Displays basic system information for the local computer.
+    Displays detailed system information for the local computer.
 .DESCRIPTION
     Collects operating system details, memory information and processor count
-    using Get-ComputerInfo.
+    using Get-ComputerInfo. Optional parameters allow inclusion of network
+    adapter information, GPU details and basic health metrics. Results can be
+    exported to CSV or JSON instead of being displayed on screen.
+.PARAMETER IncludeNetwork
+    Include network adapter information using Get-NetAdapter.
+.PARAMETER IncludeGPU
+    Include GPU information using Get-CimInstance Win32_VideoController.
+.PARAMETER HealthStatus
+    Include CPU temperature and usage statistics.
+.PARAMETER OutCsv
+    Export the collected information to 'SystemInfo.csv'.
+.PARAMETER OutJson
+    Export the collected information to 'SystemInfo.json'.
+.EXAMPLE
+    PS> .\Get-SystemInfo.ps1 -IncludeNetwork -OutJson
+    Writes system information including network adapters to SystemInfo.json.
+.EXAMPLE
+    PS> .\Get-SystemInfo.ps1 -IncludeGPU -HealthStatus -OutCsv
+    Exports system information, GPU details and health metrics to SystemInfo.csv.
 .EXAMPLE
     PS> .\Get-SystemInfo.ps1
-    Shows a brief summary of the current system.
+    Displays a brief summary of the current system in the console.
 #>
 
-Get-ComputerInfo | Select-Object OSName, OSVersion, CsTotalPhysicalMemory, CsNumberOfLogicalProcessors, CsSystemType
+[CmdletBinding()]
+param(
+    [switch]$IncludeNetwork,
+    [switch]$IncludeGPU,
+    [switch]$HealthStatus,
+    [switch]$OutCsv,
+    [switch]$OutJson
+)
+
+$sys = Get-ComputerInfo |
+    Select-Object OSName, OSVersion, CsTotalPhysicalMemory,
+                  CsNumberOfLogicalProcessors, CsSystemType
+
+if ($IncludeNetwork) {
+    $net = Get-NetAdapter |
+        Select-Object Name, InterfaceDescription, Status, MacAddress
+    $sys | Add-Member -MemberType NoteProperty -Name NetworkAdapters -Value $net
+}
+
+if ($IncludeGPU) {
+    $gpu = Get-CimInstance Win32_VideoController |
+        Select-Object Name, DriverVersion
+    $sys | Add-Member -MemberType NoteProperty -Name GPUs -Value $gpu
+}
+
+if ($HealthStatus) {
+    $cpuLoad = (Get-CimInstance Win32_Processor).LoadPercentage
+    $tempObj = Get-WmiObject -Namespace root/wmi -Class MSAcpi_ThermalZoneTemperature -ErrorAction SilentlyContinue | Select-Object -First 1
+    if ($tempObj) {
+        $tempC = [math]::Round(($tempObj.CurrentTemperature - 2732) / 10, 1)
+    }
+    $health = [pscustomobject]@{
+        CpuLoadPercentage    = $cpuLoad
+        CpuTemperatureCelsius = $tempC
+    }
+    $sys | Add-Member -MemberType NoteProperty -Name HealthStatus -Value $health
+}
+
+if ($OutCsv) {
+    $sys | ConvertTo-Csv -NoTypeInformation | Set-Content -Path '.\SystemInfo.csv'
+}
+
+if ($OutJson) {
+    $sys | ConvertTo-Json -Depth 4 | Set-Content -Path '.\SystemInfo.json'
+}
+
+if (-not $OutCsv -and -not $OutJson) {
+    $sys | Format-List *
+}
+


### PR DESCRIPTION
## Summary
- enhance `Get-SystemInfo.ps1` with optional switches
- gather network and GPU information when requested
- gather simple health metrics via WMI
- support CSV or JSON output
- update help text with usage examples

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_688b6fe2fbb4833290d5a36e3190a764