### PR TITLE
Ensure Teams sessions disconnect

### DIFF
--- a/scripts/powershell/TeamsManagement.ps1
+++ b/scripts/powershell/TeamsManagement.ps1
@@ -63,12 +63,8 @@ try {
 
 try {
     Connect-MicrosoftTeams -ErrorAction Stop | Out-Null
-} catch {
-    Write-Error "Failed to connect to Microsoft Teams. $_"
-    return
-}
 
-switch ($Action.ToLower()) {
+    switch ($Action.ToLower()) {
     'list' {
         Get-Team
     }
@@ -225,4 +221,9 @@ switch ($Action.ToLower()) {
             Write-Error "Failed bulk add operation. $_"
         }
     }
+}
+} catch {
+    Write-Error "Failed to execute Teams action. $_"
+} finally {
+    Disconnect-MicrosoftTeams | Out-Null
 }


### PR DESCRIPTION
## Summary
- make sure TeamsManagement.ps1 always closes the Teams session

## Testing
- `apt-get update` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_688c6c0d96188332ac613f6c649028c4