### PR TITLE
Add checksum verification for Ollama installer

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,7 @@ Chacun des scripts possède des paramètres décrits en début de fichier.
 
 ```bash
 # Installation de l'API Mistral
+# Le script télécharge install.sh séparément et vérifie son empreinte SHA-256
 bash scripts/linux/setup_api.sh
 # Puis lancer l'API
 python3 ~/mistral_api.py

--- a/scripts/linux/setup_api.sh
+++ b/scripts/linux/setup_api.sh
@@ -21,14 +21,17 @@ pip3 install --upgrade pip
 pip3 install flask requests
 
 echo "⬇️ Installation d'Ollama..."
-# SECURITY WARNING: the line below downloads a script from the internet and
-# pipes it directly to Bash. If the remote server or network is compromised,
-# malicious code could be executed with your permissions. To reduce the risk,
-# download the script separately and verify its integrity before running it:
-#   curl -fsSL https://ollama.ai/install.sh -o install.sh
-#   sha256sum install.sh  # compare with the official checksum
-#   bash install.sh
-curl -fsSL https://ollama.ai/install.sh | bash
+# Télécharge install.sh séparément, vérifie son empreinte SHA-256 puis l'exécute.
+# Le fichier install.sh.sha256 fourni par Ollama contient la somme attendue.
+curl -fsSL https://ollama.ai/install.sh -o install.sh
+curl -fsSL https://ollama.ai/install.sh.sha256 -o install.sh.sha256
+if sha256sum -c install.sh.sha256; then
+    bash install.sh
+    rm -f install.sh install.sh.sha256
+else
+    echo "❌ Échec de la vérification de l'intégrité d'install.sh" >&2
+    exit 1
+fi
 
 echo "📦 Téléchargement du modèle Mistral..."
 ollama pull mistral


### PR DESCRIPTION
## Summary
- enhance `setup_api.sh` to download `install.sh` and verify its SHA‑256 hash
- document the new verification step in the README

## Testing
- `bash -n scripts/linux/setup_api.sh`

------
https://chatgpt.com/codex/tasks/task_e_688c6e9caa1083328172167137800bcb