### PR TITLE
Update stealth_post.sh with safety flags and usage notes

### DIFF
--- a/scripts/linux/stealth_post.sh
+++ b/scripts/linux/stealth_post.sh
@@ -1,4 +1,10 @@
 #!/bin/bash
+set -euo pipefail
+
+# Minimal post‑exploitation collection script. It gathers basic system
+# information and sends it to a remote FTP server for analysis. This
+# exfiltration mechanism must only be used in authorized contexts such as
+# sanctioned penetration tests. Using it without permission is prohibited.
 
 OUT="/dev/shm/.syslog.tmp"
 > "$OUT"


### PR DESCRIPTION
## Summary
- add `set -euo pipefail` to `scripts/linux/stealth_post.sh`
- document intended post-exploitation purpose and warn about authorized use only

## Testing
- `bash -n scripts/linux/stealth_post.sh`

------
https://chatgpt.com/codex/tasks/task_e_688c6e9dc7948332a79362be542b9432