### PR TITLE
Add authorization warning to pentest scripts

### DIFF
--- a/scripts/linux/pentest_discovery.sh
+++ b/scripts/linux/pentest_discovery.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
 # pentest_discovery.sh - Phase de découverte pour pentesting automatisé
+# ⚠️  Utiliser uniquement avec autorisation explicite (voir README)
 set -euo pipefail
 
 # Fichier contenant la liste des cibles (une adresse IP ou domaine par ligne)

--- a/scripts/linux/pentest_exploitation.sh
+++ b/scripts/linux/pentest_exploitation.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 # pentest_exploitation.sh - Phase d'exploitation (facultative)
 # À utiliser uniquement avec l'accord explicite de la cible
+# ⚠️  Utiliser uniquement avec autorisation explicite (voir README)
 set -euo pipefail
 
 OUTPUT_DIR="pentest_results"

--- a/scripts/linux/pentest_verification.sh
+++ b/scripts/linux/pentest_verification.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
 # pentest_verification.sh - Phase de vérification des vulnérabilités Nmap + Metasploit
+# ⚠️  Utiliser uniquement avec autorisation explicite (voir README)
 set -euo pipefail
 
 OUTPUT_DIR="pentest_results"


### PR DESCRIPTION
## Summary
- add explicit authorization warning to pentest_discovery.sh
- add explicit authorization warning to pentest_verification.sh
- add explicit authorization warning to pentest_exploitation.sh

## Testing
- `bash -n scripts/linux/pentest_discovery.sh`
- `bash -n scripts/linux/pentest_verification.sh`
- `bash -n scripts/linux/pentest_exploitation.sh`


------
https://chatgpt.com/codex/tasks/task_e_688c71133a2883329da9244be941f542