### PR TITLE
Add script linting job

### DIFF
--- a/.github/workflows/powershell-test.yml
+++ b/.github/workflows/powershell-test.yml
@@ -5,6 +5,21 @@ on:
   pull_request:
 
 jobs:
+  lint-scripts:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+    - name: Install dependencies
+      run: |
+        sudo apt-get update
+        sudo apt-get install -y shellcheck
+        pwsh -Command Install-Module -Name PSScriptAnalyzer -Force -Scope CurrentUser
+    - name: Run shellcheck
+      run: shellcheck scripts/linux/*.sh
+    - name: Run PSScriptAnalyzer
+      shell: pwsh
+      run: Invoke-ScriptAnalyzer -Path './scripts/powershell' -Recurse -ErrorAction Stop
+
   test-scripts:
     runs-on: windows-latest
     steps:


### PR DESCRIPTION
## Summary
- lint bash and PowerShell scripts in CI

## Testing
- `shellcheck scripts/linux/*.sh` *(fails: command not found)*
- `pwsh -Command Invoke-ScriptAnalyzer -Path scripts/powershell` *(fails: command not found)*
- `sudo apt-get update` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_688c71171b1883328af2459c369d9ec0