### PR TITLE
Ensure pentest scripts find targets list

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ scripts/
 ├── sample_logs.json   # Journalisation fictive pour tests
 ```
 
-Le fichier `targets.txt` à la racine contient la liste des cibles pour les scripts de pentest.
+Le fichier `targets.txt` à la racine contient la liste des cibles pour les scripts de pentest. Les scripts Bash utilisent un chemin relatif basé sur leur propre emplacement pour le retrouver, ce qui permet de les lancer depuis n'importe quel répertoire.
 
 ## 🛠️ Prérequis / Prerequisites
 

--- a/scripts/linux/pentest_discovery.sh
+++ b/scripts/linux/pentest_discovery.sh
@@ -2,8 +2,11 @@
 # pentest_discovery.sh - Phase de découverte pour pentesting automatisé
 set -euo pipefail
 
+# Dossier du script pour localiser les ressources quel que soit le répertoire courant
+SCRIPT_DIR="$(dirname "$(realpath "$0")")"
+
 # Fichier contenant la liste des cibles (une adresse IP ou domaine par ligne)
-TARGET_LIST="targets.txt"
+TARGET_LIST="$SCRIPT_DIR/../../targets.txt"
 
 # Dossier de sortie pour les résultats
 OUTPUT_DIR="pentest_results"


### PR DESCRIPTION
## Summary
- resolve the script folder at runtime
- use that location to load `../../targets.txt`
- clarify README about how the scripts locate `targets.txt`

## Testing
- `bash -n scripts/linux/pentest_discovery.sh`

------
https://chatgpt.com/codex/tasks/task_e_688c7115d9f0833284b6b552535af0ce