### PR TITLE
Add timestamped output directories for pentest discovery

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,9 @@ bash scripts/linux/pentest_verification.sh
 bash scripts/linux/pentest_exploitation.sh
 ```
 
+Chaque exécution de `pentest_discovery.sh` crée un sous-dossier horodaté dans `pentest_results`, conservant les résultats des scans précédents.
+Each run of `pentest_discovery.sh` outputs to a timestamped subfolder inside `pentest_results`, preserving previous scan results.
+
 ## ⚠️ Disclaimer / Avertissement
 
 Pentest scripts (dont `pentest_discovery.sh`, `pentest_verification.sh`, `pentest_exploitation.sh`) et `stealth_post.sh` doivent être utilisés uniquement sur des systèmes pour lesquels vous disposez d'une autorisation explicite.

--- a/scripts/linux/pentest_discovery.sh
+++ b/scripts/linux/pentest_discovery.sh
@@ -10,7 +10,7 @@ SCRIPT_DIR="$(dirname "$(realpath "$0")")"
 TARGET_LIST="$SCRIPT_DIR/../../targets.txt"
 
 # Dossier de sortie pour les résultats
-OUTPUT_DIR="pentest_results"
+OUTPUT_DIR="pentest_results/$(date +%Y%m%d_%H%M%S)"
 mkdir -p "$OUTPUT_DIR"
 
 # Options Nmap pour collecter un maximum d'informations utiles :


### PR DESCRIPTION
## Summary
- Save pentest discovery results to a timestamped subfolder under `pentest_results`
- Document that each run creates a unique results folder

## Testing
- `bash scripts/linux/pentest_discovery.sh` *(fails: nmap: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689067de5e948332a05dde0a392c13c6