### PR TITLE
Use virtualenv for Mistral API setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,8 +69,9 @@ Chacun des scripts possède des paramètres décrits en début de fichier.
 # Installation de l'API Mistral
 # Le script télécharge install.sh séparément et vérifie son empreinte SHA-256
 bash scripts/linux/setup_api.sh
-# Puis lancer l'API
-python3 ~/mistral_api.py
+# Activer l'environnement virtuel puis lancer l'API
+source /opt/mistral-env/bin/activate
+python ~/mistral_api.py
 ```
 
 ### Scripts Kali Linux

--- a/scripts/linux/setup_api.sh
+++ b/scripts/linux/setup_api.sh
@@ -16,9 +16,12 @@ echo "🔧 Mise à jour des paquets et installation des dépendances..."
 sudo apt-get update
 sudo apt-get install -y python3 python3-pip curl
 
+python3 -m venv /opt/mistral-env
+source /opt/mistral-env/bin/activate
+
 echo "🐍 Installation des bibliothèques Python..."
-pip3 install --upgrade pip
-pip3 install flask requests
+pip install --upgrade pip
+pip install flask requests
 
 echo "⬇️ Installation d'Ollama..."
 # Télécharge install.sh séparément, vérifie son empreinte SHA-256 puis l'exécute.
@@ -59,4 +62,5 @@ if __name__ == '__main__':
 APP
 
 echo "✅ API créée avec succès : $APP_PATH"
-echo "▶️ Lancez-la avec : python3 $APP_PATH"
+echo "▶️ Avant de la lancer, activez l'environnement : source /opt/mistral-env/bin/activate"
+echo "▶️ Lancez-la avec : python $APP_PATH"


### PR DESCRIPTION
## Summary
- Create and activate `/opt/mistral-env` virtual environment in Mistral API setup script
- Install Python dependencies with `pip` inside the venv and update script messages
- Document virtual environment activation in README

## Testing
- `bash -n scripts/linux/setup_api.sh`
- `apt-get update && apt-get install -y shellcheck` *(failed: repository unsigned)*

------
https://chatgpt.com/codex/tasks/task_e_689067e2599c83329442ad83350d9863