### PR TITLE
Use repo-relative paths in pentest scripts

### DIFF
--- a/scripts/linux/pentest_discovery.sh
+++ b/scripts/linux/pentest_discovery.sh
@@ -5,12 +5,14 @@ set -euo pipefail
 
 # Dossier du script pour localiser les ressources quel que soit le répertoire courant
 SCRIPT_DIR="$(dirname "$(realpath "$0")")"
+# Racine du dépôt
+REPO_ROOT="$(realpath "$SCRIPT_DIR/../..")"
 
 # Fichier contenant la liste des cibles (une adresse IP ou domaine par ligne)
-TARGET_LIST="$SCRIPT_DIR/../../targets.txt"
+TARGET_LIST="$REPO_ROOT/targets.txt"
 
 # Dossier de sortie pour les résultats
-OUTPUT_DIR="pentest_results/$(date +%Y%m%d_%H%M%S)"
+OUTPUT_DIR="$REPO_ROOT/pentest_results/$(date +%Y%m%d_%H%M%S)"
 mkdir -p "$OUTPUT_DIR"
 
 # Options Nmap pour collecter un maximum d'informations utiles :

--- a/scripts/linux/pentest_exploitation.sh
+++ b/scripts/linux/pentest_exploitation.sh
@@ -4,8 +4,9 @@
 # ⚠️  Utiliser uniquement avec autorisation explicite (voir README)
 set -euo pipefail
 
-OUTPUT_DIR="pentest_results"
-RESULTS_DIR="$OUTPUT_DIR"
+SCRIPT_DIR="$(dirname "$(realpath "$0")")"
+REPO_ROOT="$(realpath "$SCRIPT_DIR/../..")"
+RESULTS_DIR="$REPO_ROOT/pentest_results"
 
 if [[ ! -d "$RESULTS_DIR" ]]; then
     echo "Dossier $RESULTS_DIR introuvable" >&2

--- a/scripts/linux/pentest_verification.sh
+++ b/scripts/linux/pentest_verification.sh
@@ -3,8 +3,10 @@
 # ⚠️  Utiliser uniquement avec autorisation explicite (voir README)
 set -euo pipefail
 
-OUTPUT_DIR="pentest_results"
-RESULTS_DIR="$OUTPUT_DIR"
+# Répertoires basés sur l'emplacement du script pour exécution depuis n'importe où
+SCRIPT_DIR="$(dirname "$(realpath "$0")")"
+REPO_ROOT="$(realpath "$SCRIPT_DIR/../..")"
+RESULTS_DIR="$REPO_ROOT/pentest_results"
 SUMMARY_FILE="$RESULTS_DIR/summary_vuln.log"
 
 mkdir -p "$RESULTS_DIR"


### PR DESCRIPTION
## Summary
- Resolve targets file and results folder from the repository root
- Allow pentest scripts to run from any working directory

## Testing
- `bash -n scripts/linux/pentest_discovery.sh`
- `bash -n scripts/linux/pentest_verification.sh`
- `bash -n scripts/linux/pentest_exploitation.sh`


------
https://chatgpt.com/codex/tasks/task_e_6895ea6d4d488332b4dd75b437d479d3