### PR TITLE
Handle results directory creation failures

### DIFF
--- a/scripts/linux/pentest_verification.sh
+++ b/scripts/linux/pentest_verification.sh
@@ -9,13 +9,11 @@ REPO_ROOT="$(realpath "$SCRIPT_DIR/../..")"
 RESULTS_DIR="$REPO_ROOT/pentest_results"
 SUMMARY_FILE="$RESULTS_DIR/summary_vuln.log"
 
-mkdir -p "$RESULTS_DIR"
-echo -e "Résumé des vulnérabilités - $(date)\n" > "$SUMMARY_FILE"
-
-if [[ ! -d "$RESULTS_DIR" ]]; then
-    echo "❌ Dossier $RESULTS_DIR introuvable." >&2
+if ! mkdir -p "$RESULTS_DIR"; then
+    echo "❌ Impossible de créer le dossier $RESULTS_DIR." >&2
     exit 1
 fi
+echo -e "Résumé des vulnérabilités - $(date)\n" > "$SUMMARY_FILE"
 
 # Ensure required tools are available
 for cmd in nmap msfconsole; do


### PR DESCRIPTION
## Summary
- Add error handling when creating the pentest results directory
- Remove redundant directory existence check in pentest verification script

## Testing
- `bash -n scripts/linux/pentest_verification.sh`


------
https://chatgpt.com/codex/tasks/task_e_6899ae8c8c8483329372632cbcea8bef