### PR TITLE
Ensure admin rights via PowerShell Requires

### DIFF
--- a/scripts/powershell/ManageServices.ps1
+++ b/scripts/powershell/ManageServices.ps1
@@ -1,3 +1,4 @@
+#Requires -RunAsAdministrator
 <#
 .SYNOPSIS
     Starts, stops, restarts or checks the status of a Windows service.
@@ -24,12 +25,6 @@ param(
     [Parameter(Mandatory=$true)]
     [string]$ServiceName
 )
-
-# Ensure script runs with administrative privileges
-if (-not ([Security.Principal.WindowsPrincipal] [Security.Principal.WindowsIdentity]::GetCurrent()).IsInRole([Security.Principal.WindowsBuiltinRole]::Administrator)) {
-    Write-Error 'This script must be run as Administrator.'
-    return
-}
 
 try {
     $service = Get-Service -Name $ServiceName -ErrorAction Stop

--- a/scripts/powershell/UserManagement.ps1
+++ b/scripts/powershell/UserManagement.ps1
@@ -1,3 +1,4 @@
+#Requires -RunAsAdministrator
 <#
 .SYNOPSIS
     Creates, removes or lists local user accounts.
@@ -28,12 +29,6 @@ param(
     [string]$UserName,
     [SecureString]$Password
 )
-
-# Ensure script runs with administrative privileges
-if (-not ([Security.Principal.WindowsPrincipal] [Security.Principal.WindowsIdentity]::GetCurrent()).IsInRole([Security.Principal.WindowsBuiltinRole]::Administrator)) {
-    Write-Error 'This script must be run as Administrator.'
-    return
-}
 
 switch ($Action.ToLower()) {
     'create' {


### PR DESCRIPTION
## Summary
- enforce admin execution in ManageServices.ps1 using `#Requires -RunAsAdministrator`
- enforce admin execution in UserManagement.ps1 using `#Requires -RunAsAdministrator`
- drop manual privilege checks from both scripts

## Testing
- `pwsh -v` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6899c866f8d08332974164caa5d0cefe