### PR TITLE
Disconnect Teams session after actions

### DIFF
--- a/scripts/powershell/TeamsManagement.ps1
+++ b/scripts/powershell/TeamsManagement.ps1
@@ -264,3 +264,5 @@ switch ($Action.ToLower()) {
         }
     }
 }
+
+Disconnect-MicrosoftTeams -ErrorAction SilentlyContinue


### PR DESCRIPTION
## Summary
- ensure TeamsManagement disconnects from Teams after operations, unless explicitly connecting or disconnecting

## Testing
- `apt-get update` (fails: repository not signed)
- `apt-get install -y powershell` (fails: package not found)
- `pwsh -c "$PSVersionTable"` (fails: command not found)


------
https://chatgpt.com/codex/tasks/task_e_6899c86751a883328cac5c8ba1ca570c