### PR TITLE
feat: parameterize pentest discovery script

### DIFF
--- a/scripts/linux/pentest_discovery.sh
+++ b/scripts/linux/pentest_discovery.sh
@@ -13,6 +13,25 @@ TARGET_LIST="$REPO_ROOT/targets.txt"
 
 # Dossier de sortie pour les résultats
 OUTPUT_DIR="$REPO_ROOT/pentest_results/$(date +%Y%m%d_%H%M%S)"
+
+# Parse les paramètres optionnels
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --targets)
+            TARGET_LIST="$2"
+            shift 2
+            ;;
+        --outdir)
+            OUTPUT_DIR="$2"
+            shift 2
+            ;;
+        *)
+            echo "Usage: $0 [--targets fichier] [--outdir dossier]" >&2
+            exit 1
+            ;;
+    esac
+done
+
 mkdir -p "$OUTPUT_DIR"
 LOG_FILE="$OUTPUT_DIR/scan_errors.log"
 
@@ -32,6 +51,12 @@ fi
 # Avertissement si non root
 if [[ $EUID -ne 0 ]]; then
     echo "⚠️ Ce script devrait être exécuté en tant que root pour une détection complète (OS, ports ICMP...)" >&2
+fi
+
+# Vérifie la présence de nmap
+if ! command -v nmap >/dev/null 2>&1; then
+    echo "❌ nmap introuvable, installez-le" >&2
+    exit 1
 fi
 
 # Lecture de chaque cible


### PR DESCRIPTION
## Summary
- allow specifying custom targets file and output directory
- verify nmap availability before running scans

## Testing
- `bash -n scripts/linux/pentest_discovery.sh`
- `bash scripts/linux/pentest_discovery.sh --targets targets.txt --outdir /tmp/pentest_test` *(fails: nmap introuvable, installez-le)*

------
https://chatgpt.com/codex/tasks/task_e_689b2554650083328c419574c085a83d