### PR TITLE
Add CVE-based exploit suggestions to pentest script

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,7 @@ bash scripts/linux/pentest_discovery.sh
 bash scripts/linux/pentest_verification.sh
 # Phase d'exploitation (si autorisée)
 bash scripts/linux/pentest_exploitation.sh
+# Génère un fichier de suggestions avec searchsploit si des CVE ont été détectées
 # Exfiltration basique (si autorisée)
 export FTP_USER="utilisateur"
 export FTP_PASS="motdepasse"

--- a/scripts/linux/pentest_exploitation.sh
+++ b/scripts/linux/pentest_exploitation.sh
@@ -7,17 +7,62 @@ set -euo pipefail
 SCRIPT_DIR="$(dirname "$(realpath "$0")")"
 REPO_ROOT="$(realpath "$SCRIPT_DIR/../..")"
 RESULTS_DIR="$REPO_ROOT/pentest_results"
+SEARCH_FILE=""
+
+# Parse optional parameters
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --results)
+            RESULTS_DIR="$2"
+            shift 2
+            ;;
+        --search-file)
+            SEARCH_FILE="$2"
+            shift 2
+            ;;
+        *)
+            echo "Usage: $0 [--results dir] [--search-file file]" >&2
+            exit 1
+            ;;
+    esac
+done
 
 if [[ ! -d "$RESULTS_DIR" ]]; then
     echo "Dossier $RESULTS_DIR introuvable" >&2
     exit 1
 fi
 
+if [[ -z "$SEARCH_FILE" ]]; then
+    SEARCH_FILE="$RESULTS_DIR/exploitation_suggestions.txt"
+fi
+
+: >"$SEARCH_FILE"
+
+if command -v searchsploit >/dev/null; then
+    SEARCHSPLOIT_AVAILABLE=1
+else
+    echo "ℹ️  searchsploit non trouvé, suggestions non générées" >&2
+    SEARCHSPLOIT_AVAILABLE=0
+fi
+
 for xml in "$RESULTS_DIR"/*_vuln.xml; do
     [[ ! -f "$xml" ]] && continue
     host=$(basename "$xml" _vuln.xml)
     echo "[+] Phase d'exploitation pour $host"
+
+    cve_file="$RESULTS_DIR/${host}_cves.list"
+    if [[ $SEARCHSPLOIT_AVAILABLE -eq 1 && -s "$cve_file" ]]; then
+        while read -r cve; do
+            echo "## $host - $cve" >>"$SEARCH_FILE"
+            searchsploit "$cve" >>"$SEARCH_FILE" 2>/dev/null || true
+            echo >>"$SEARCH_FILE"
+        done <"$cve_file"
+    else
+        echo "    -> Aucune CVE ou searchsploit indisponible"
+    fi
+
     echo "    -> Ici, ajoutez vos commandes d'exploitation (Metasploit, scripts)"
 done
 
 echo "✅ Exploitation terminée (si configurée)"
+[[ -s "$SEARCH_FILE" ]] && echo "📄 Suggestions enregistrées dans $SEARCH_FILE"


### PR DESCRIPTION
## Summary
- parse optional result paths and output file in pentest_exploitation.sh
- generate searchsploit suggestions for CVE lists
- document exploitation suggestions in README

## Testing
- `bash -n scripts/linux/pentest_exploitation.sh`
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_689b32f86ec483328dc93e12cea81402