### PR TITLE
Add dependency check helper script

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ Ce dépôt contient une collection de scripts PowerShell utiles pour l'administr
 ```
 scripts/
 ├── linux/             # Scripts Bash pour Linux
+│   ├── check_dependencies.sh
 │   ├── setup_api.sh
 │   ├── pentest_discovery.sh
 │   ├── pentest_verification.sh
@@ -81,6 +82,9 @@ python ~/mistral_api.py
 ### Scripts Kali Linux
 
 ```bash
+
+# Vérifier les dépendances nécessaires
+bash scripts/linux/check_dependencies.sh
 
 # Phase de découverte (scan complet et scripts de vulnérabilités)
 bash scripts/linux/pentest_discovery.sh

--- a/scripts/linux/check_dependencies.sh
+++ b/scripts/linux/check_dependencies.sh
@@ -1,0 +1,40 @@
+#!/bin/bash
+# check_dependencies.sh - Vérifie la présence des outils requis pour les scripts du dépôt
+# ⚠️  Utiliser avant d'exécuter les scripts pour s'assurer que toutes les dépendances sont installées
+set -euo pipefail
+
+# Outils en ligne de commande requis
+CLI_DEPS=(nmap gvm-cli pwsh)
+
+# Modules PowerShell à vérifier
+PS_MODULES=("Hyper-V" "ExchangeOnlineManagement" "MicrosoftTeams" "PnP.PowerShell")
+
+missing=0
+
+for cmd in "${CLI_DEPS[@]}"; do
+    if command -v "$cmd" >/dev/null 2>&1; then
+        echo "✅ $cmd disponible"
+    else
+        echo "❌ $cmd introuvable" >&2
+        missing=1
+    fi
+done
+
+if command -v pwsh >/dev/null 2>&1; then
+    for mod in "${PS_MODULES[@]}"; do
+        if pwsh -NoProfile -Command "Get-Module -ListAvailable -Name '$mod' | Out-Null" 2>/dev/null; then
+            echo "✅ Module PowerShell $mod disponible"
+        else
+            echo "❌ Module PowerShell $mod manquant" >&2
+            missing=1
+        fi
+    done
+else
+    echo "❌ pwsh introuvable - impossible de vérifier les modules PowerShell" >&2
+fi
+
+if [[ $missing -eq 0 ]]; then
+    echo "Toutes les dépendances sont satisfaites."
+else
+    echo "Certaines dépendances sont manquantes. Veuillez les installer." >&2
+fi


### PR DESCRIPTION
## Summary
- add bash script to verify required CLI tools and PowerShell modules
- document dependency check workflow in README

## Testing
- `./scripts/linux/check_dependencies.sh`
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_689c3d3534988332b8175a9bdbd12fef