### PR TITLE
feat: improve dependency checks and document subfolders

### DIFF
--- a/scripts/linux/README.md
+++ b/scripts/linux/README.md
@@ -1,0 +1,13 @@
+# Scripts Bash pour Linux
+
+Ce dossier regroupe les scripts destinés aux systèmes GNU/Linux.
+
+- `check_dependencies.sh` – vérifie la présence des outils requis et peut tenter de les installer avec l'option `--install`.
+- `setup_api.sh` – installe et configure l'API Mistral.
+- `pentest_discovery.sh` – phase de découverte lors d'un pentest.
+- `pentest_verification.sh` – vérification des vulnérabilités détectées.
+- `pentest_exploitation.sh` – exploitation des vulnérabilités.
+- `scan_wifi.sh` – analyse des réseaux Wi-Fi.
+- `stealth_post.sh` – exfiltration basique des informations.
+
+Les scripts utilisent `targets.txt` situé à la racine du dépôt pour définir les cibles de test.

--- a/scripts/linux/check_dependencies.sh
+++ b/scripts/linux/check_dependencies.sh
@@ -3,6 +3,11 @@
 # ⚠️  Utiliser avant d'exécuter les scripts pour s'assurer que toutes les dépendances sont installées
 set -euo pipefail
 
+INSTALL=false
+if [[ "${1:-}" == "--install" ]]; then
+    INSTALL=true
+fi
+
 # Outils en ligne de commande requis
 CLI_DEPS=(nmap gvm-cli pwsh)
 
@@ -17,6 +22,16 @@ for cmd in "${CLI_DEPS[@]}"; do
     else
         echo "❌ $cmd introuvable" >&2
         missing=1
+        if $INSTALL; then
+            if command -v apt-get >/dev/null 2>&1; then
+                echo "Tentative d'installation de $cmd via apt-get..."
+                sudo apt-get update -qq && sudo apt-get install -y "$cmd" || echo "Échec de l'installation de $cmd" >&2
+            else
+                echo "Veuillez installer $cmd manuellement." >&2
+            fi
+        else
+            echo "→ Installez avec : sudo apt-get install -y $cmd"
+        fi
     fi
 done
 
@@ -27,10 +42,19 @@ if command -v pwsh >/dev/null 2>&1; then
         else
             echo "❌ Module PowerShell $mod manquant" >&2
             missing=1
+            if $INSTALL; then
+                echo "Tentative d'installation du module $mod..."
+                pwsh -NoProfile -Command "Install-Module -Name '$mod' -Scope CurrentUser -Force" || echo "Échec de l'installation de $mod" >&2
+            else
+                echo "→ Installez avec : pwsh -NoProfile -Command \"Install-Module -Name '$mod'\""
+            fi
         fi
     done
 else
     echo "❌ pwsh introuvable - impossible de vérifier les modules PowerShell" >&2
+    if $INSTALL; then
+        echo "→ Installez PowerShell avec : sudo apt-get install -y powershell" >&2
+    fi
 fi
 
 if [[ $missing -eq 0 ]]; then

--- a/scripts/powershell/README.md
+++ b/scripts/powershell/README.md
@@ -1,0 +1,15 @@
+# Scripts PowerShell pour Windows
+
+Ce dossier regroupe des scripts PowerShell pour l'administration système et la sécurité.
+
+- `DiskUsageReport.ps1` – génère un rapport d'utilisation disque.
+- `Get-SystemInfo.ps1` – affiche des informations système.
+- `ManageServices.ps1` – gère l'état des services.
+- `VMManagement.ps1` – gère des machines virtuelles Hyper-V.
+- `LinkCrawler.ps1` – explore les liens d'un site.
+- `TeamsManagement.ps1` – administre Microsoft Teams.
+- `SharePointManagement.ps1` – automatise des actions sur SharePoint.
+- `UserManagement.ps1` – gestion de comptes utilisateurs.
+- `SecurityCheck.ps1` – vérifie quelques paramètres de sécurité.
+
+Chaque script possède un bloc d'aide accessible avec `Get-Help`.


### PR DESCRIPTION
## Summary
- add `--install` option to check_dependencies.sh to suggest or install missing tools and PowerShell modules
- document Linux and PowerShell script directories with new READMEs

## Testing
- `bash scripts/linux/check_dependencies.sh > /tmp/check_all.log 2>&1 && cat /tmp/check_all.log`


------
https://chatgpt.com/codex/tasks/task_e_689d934cb2e48332b5ec5cb269a9c7b7