### PR TITLE
feat: add cross distro package installation

### DIFF
--- a/scripts/linux/README.md
+++ b/scripts/linux/README.md
@@ -2,7 +2,7 @@
 
 Ce dossier regroupe les scripts destinés aux systèmes GNU/Linux.
 
-- `check_dependencies.sh` – vérifie la présence des outils requis et peut tenter de les installer avec l'option `--install`.
+- `check_dependencies.sh` – vérifie la présence des outils requis et peut tenter de les installer avec l'option `--install` (compatible avec `apt-get`, `yum`, `dnf` et `pacman`).
 - `setup_api.sh` – installe et configure l'API Mistral.
 - `pentest_discovery.sh` – phase de découverte lors d'un pentest.
 - `pentest_verification.sh` – vérification des vulnérabilités détectées.


### PR DESCRIPTION
## Summary
- add `install_package` function supporting apt-get, yum, dnf, and pacman
- replace direct apt-get calls with cross-distro helper
- document supported package managers in README

## Testing
- `bash -n scripts/linux/check_dependencies.sh`
- `bash scripts/linux/check_dependencies.sh`


------
https://chatgpt.com/codex/tasks/task_e_689da7203cec83329401c0f9b6920e94