### PR TITLE
Handle gvm-cli failures in pentest verification

### DIFF
--- a/scripts/linux/pentest_verification.sh
+++ b/scripts/linux/pentest_verification.sh
@@ -51,9 +51,12 @@ for xml in "$RESULTS_DIR"/*_discovery.xml; do
     echo "[...] Scan OpenVAS sur $host"
     OPENVAS_XML="$RESULTS_DIR/${host}_openvas.xml"
     if command -v gvm-cli >/dev/null; then
-        gvm-cli socket --gmp-username "${GVM_USER:-admin}" \
+        if ! gvm-cli socket --gmp-username "${GVM_USER:-admin}" \
             --gmp-password "${GVM_PASSWORD:-admin}" \
-            --xml "<start_scan target='$host'/>" > "$OPENVAS_XML" 2>/dev/null
+            --xml "<start_scan target='$host'/>" > "$OPENVAS_XML" 2>/dev/null; then
+            echo "$host - OpenVAS échec" >> "$SUMMARY_FILE"
+            continue
+        fi
         grep -oE 'CVE-[0-9]+-[0-9]+' "$OPENVAS_XML" | sort -u \
             > "$RESULTS_DIR/${host}_cves.list" || true
         echo "$host - OpenVAS OK" >> "$SUMMARY_FILE"


### PR DESCRIPTION
## Summary
- check `gvm-cli` exit status and log OpenVAS errors to the summary file
- skip remaining steps for a host when OpenVAS authentication fails

## Testing
- `PATH=/tmp/fakebin:$PATH GVM_USER=bad GVM_PASSWORD=bad bash scripts/linux/pentest_verification.sh`


------
https://chatgpt.com/codex/tasks/task_e_689da71c866c8332b6ac52ac14ebb506