### PR TITLE
Check sha256sum availability before verifying install script

### DIFF
--- a/scripts/linux/setup_api.sh
+++ b/scripts/linux/setup_api.sh
@@ -71,6 +71,11 @@ if [[ "$OFFLINE" = false ]]; then
     # Le fichier install.sh.sha256 fourni par Ollama contient la somme attendue.
     curl -fsSL https://ollama.ai/install.sh -o install.sh
     curl -fsSL https://ollama.ai/install.sh.sha256 -o install.sh.sha256
+    # Vérifie la disponibilité de sha256sum avant la vérification d'intégrité
+    if ! command -v sha256sum >/dev/null 2>&1; then
+        echo "❌ sha256sum n'est pas disponible" >&2
+        exit 1
+    fi
     if sha256sum -c install.sh.sha256; then
         bash install.sh
         rm -f install.sh install.sh.sha256


### PR DESCRIPTION
## Summary
- Ensure `sha256sum` is present before verifying Ollama install script

## Testing
- `bash -n scripts/linux/setup_api.sh`
- `shellcheck scripts/linux/setup_api.sh` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed / 403)*

------
https://chatgpt.com/codex/tasks/task_e_689da71b0dec83328fb9e63224d82e8b