### PR TITLE
Add logging to WiFi scan script

### DIFF
--- a/scripts/linux/README.md
+++ b/scripts/linux/README.md
@@ -8,6 +8,7 @@ Ce dossier regroupe les scripts destinés aux systèmes GNU/Linux.
 - `pentest_verification.sh` – vérification des vulnérabilités détectées.
 - `pentest_exploitation.sh` – exploitation des vulnérabilités.
 - `scan_wifi.sh` – analyse des réseaux Wi-Fi.
+  Le script consigne désormais toutes les actions et erreurs dans `wifi_captures/scan_wifi.log`.
 - `stealth_post.sh` – exfiltration basique des informations.
 
 Les scripts utilisent `targets.txt` situé à la racine du dépôt pour définir les cibles de test.

--- a/scripts/linux/scan_wifi.sh
+++ b/scripts/linux/scan_wifi.sh
@@ -56,6 +56,8 @@ done
 MONITOR_IF="${INTERFACE}mon"
 
 mkdir -p "$OUTPUT_DIR"
+LOG_FILE="$OUTPUT_DIR/scan_wifi.log"
+exec > >(tee -a "$LOG_FILE") 2>&1
 
 echo "[*] Activation du mode monitor sur $INTERFACE..."
 airmon-ng start "$INTERFACE" >/dev/null
@@ -99,4 +101,6 @@ if [[ -f "$HANDSHAKE_FILE" ]]; then
 else
     echo "❌ Handshake non trouvé" >&2
 fi
+
+echo "📄 Journal enregistré dans $LOG_FILE"
 


### PR DESCRIPTION
## Summary
- Log all scan_wifi.sh actions and errors to a file
- Document WiFi scan logging in Linux scripts README

## Testing
- `bash -n scripts/linux/scan_wifi.sh`
- `apt-get update && apt-get install -y shellcheck` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_689dbc6ad48c8332aaac560af25a0ff3