### PR TITLE
feat: allow custom nmap options

### DIFF
--- a/scripts/linux/pentest_discovery.sh
+++ b/scripts/linux/pentest_discovery.sh
@@ -15,22 +15,36 @@ TARGET_LIST="$REPO_ROOT/targets.txt"
 OUTPUT_DIR="$REPO_ROOT/pentest_results/$(date +%Y%m%d_%H%M%S)"
 
 # Parse les paramètres optionnels
-while [[ $# -gt 0 ]]; do
-    case "$1" in
-        --targets)
-            TARGET_LIST="$2"
-            shift 2
-            ;;
-        --outdir)
-            OUTPUT_DIR="$2"
-            shift 2
+NMAP_USER_OPTS=""
+usage() {
+    echo "Usage: $0 [--targets fichier] [--outdir dossier] [--nmap-opts \"options\"]" >&2
+    exit 1
+}
+
+while getopts ":-:" opt; do
+    case "$opt" in
+        -)
+            case "$OPTARG" in
+                targets)
+                    TARGET_LIST="${!OPTIND}"; OPTIND=$((OPTIND + 1))
+                    ;;
+                outdir)
+                    OUTPUT_DIR="${!OPTIND}"; OPTIND=$((OPTIND + 1))
+                    ;;
+                nmap-opts)
+                    NMAP_USER_OPTS="${!OPTIND}"; OPTIND=$((OPTIND + 1))
+                    ;;
+                *)
+                    usage
+                    ;;
+            esac
             ;;
         *)
-            echo "Usage: $0 [--targets fichier] [--outdir dossier]" >&2
-            exit 1
+            usage
             ;;
     esac
 done
+shift $((OPTIND - 1))
 
 mkdir -p "$OUTPUT_DIR"
 LOG_FILE="$OUTPUT_DIR/scan_errors.log"
@@ -41,6 +55,7 @@ LOG_FILE="$OUTPUT_DIR/scan_errors.log"
 # -O  : détection d'OS
 # --script vuln : scripts de vulnérabilités connus
 NMAP_OPTS="-sC -sV -O --script vuln"
+[[ -n "$NMAP_USER_OPTS" ]] && NMAP_OPTS="$NMAP_OPTS $NMAP_USER_OPTS"
 
 # Vérifie l'existence du fichier de cibles
 if [[ ! -f "$TARGET_LIST" ]]; then


### PR DESCRIPTION
## Summary
- parse long options with getopts, including new `--nmap-opts`
- merge user-provided nmap options with defaults before scan

## Testing
- `bash -n scripts/linux/pentest_discovery.sh`
- `bash scripts/linux/pentest_discovery.sh --nmap-opts "-F" --targets targets.txt --outdir /tmp/test` *(fails: nmap introuvable)*

------
https://chatgpt.com/codex/tasks/task_e_689dcddb56408332827583cb709d3239