### PR TITLE
Parallelize vulnerability scans

### DIFF
--- a/scripts/linux/pentest_verification.sh
+++ b/scripts/linux/pentest_verification.sh
@@ -2,6 +2,7 @@
 # pentest_verification.sh - Phase de vérification des vulnérabilités Nmap + Metasploit
 # ⚠️  Utiliser uniquement avec autorisation explicite (voir README)
 set -euo pipefail
+shopt -s nullglob
 
 # Répertoires basés sur l'emplacement du script pour exécution depuis n'importe où
 SCRIPT_DIR="$(dirname "$(realpath "$0")")"
@@ -26,7 +27,6 @@ done
 count=0
 
 for xml in "$RESULTS_DIR"/*_discovery.xml; do
-    [[ ! -f "$xml" ]] && continue
 
     host=$(basename "$xml" _discovery.xml)
     echo -e "\n[🔎] Vérification des vulnérabilités pour : $host"
@@ -44,27 +44,41 @@ for xml in "$RESULTS_DIR"/*_discovery.xml; do
         continue
     fi
 
-    # Lancer le scan avec détection de vulnérabilités
+    # Lancer les scans en parallèle
     echo "[...] Scan Nmap vulnérabilités sur $host"
-    nmap --script vuln -oX "$RESULTS_DIR/${host}_vuln.xml" "$host"
+    nmap --script vuln -oX "$RESULTS_DIR/${host}_vuln.xml" "$host" &
+    nmap_pid=$!
 
     echo "[...] Scan OpenVAS sur $host"
     OPENVAS_XML="$RESULTS_DIR/${host}_openvas.xml"
+    openvas_pid=""
     if command -v gvm-cli >/dev/null; then
-        if ! gvm-cli socket --gmp-username "${GVM_USER:-admin}" \
+        gvm-cli socket --gmp-username "${GVM_USER:-admin}" \
             --gmp-password "${GVM_PASSWORD:-admin}" \
-            --xml "<start_scan target='$host'/>" > "$OPENVAS_XML" 2>/dev/null; then
-            echo "$host - OpenVAS échec" >> "$SUMMARY_FILE"
-            continue
-        fi
-        grep -oE 'CVE-[0-9]+-[0-9]+' "$OPENVAS_XML" | sort -u \
-            > "$RESULTS_DIR/${host}_cves.list" || true
-        echo "$host - OpenVAS OK" >> "$SUMMARY_FILE"
+            --xml "<start_scan target='$host'/>" > "$OPENVAS_XML" 2>/dev/null &
+        openvas_pid=$!
     else
         echo "$host - OpenVAS indisponible" >> "$SUMMARY_FILE"
     fi
 
-    echo "$host - Scan Nmap OK" >> "$SUMMARY_FILE"
+    if wait "$nmap_pid"; then
+        echo "$host - Scan Nmap OK" >> "$SUMMARY_FILE"
+    else
+        echo "$host - Scan Nmap échec" >> "$SUMMARY_FILE"
+        continue
+    fi
+
+    if [[ -n "$openvas_pid" ]]; then
+        if wait "$openvas_pid"; then
+            grep -oE 'CVE-[0-9]+-[0-9]+' "$OPENVAS_XML" | sort -u \
+                > "$RESULTS_DIR/${host}_cves.list" || true
+            echo "$host - OpenVAS OK" >> "$SUMMARY_FILE"
+        else
+            echo "$host - OpenVAS échec" >> "$SUMMARY_FILE"
+            continue
+        fi
+    fi
+
     ((count++))
 
     # Phase Metasploit automatique (recon uniquement)


### PR DESCRIPTION
## Summary
- Avoid loop iteration when no discovery files by enabling `nullglob`
- Run Nmap and OpenVAS scans in parallel and synchronize with `wait`

## Testing
- `bash -n scripts/linux/pentest_verification.sh`
- `shellcheck scripts/linux/pentest_verification.sh` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689dcdf8bf6c8332a18f1cb03efcea7b