### PR TITLE
feat: enhance dependency checker

### DIFF
--- a/scripts/linux/README.md
+++ b/scripts/linux/README.md
@@ -2,7 +2,7 @@
 
 Ce dossier regroupe les scripts destinés aux systèmes GNU/Linux.
 
-- `check_dependencies.sh` – vérifie la présence des outils requis et peut tenter de les installer avec l'option `--install` (compatible avec `apt-get`, `yum`, `dnf` et `pacman`).
+- `check_dependencies.sh` – vérifie la présence des outils requis. Options : `--install` pour installer, `--dry-run` pour simuler, `--prefix DIR` pour une installation utilisateur et `--help` pour afficher l'usage (compatible avec `apt-get`, `yum`, `dnf` et `pacman`).
 - `setup_api.sh` – installe et configure l'API Mistral.
 - `pentest_discovery.sh` – phase de découverte lors d'un pentest.
 - `pentest_verification.sh` – vérification des vulnérabilités détectées.


### PR DESCRIPTION
## Summary
- add --help, --dry-run, and --prefix options to check_dependencies.sh
- update dependency checker to run apt-get update once and allow user installs
- document new options in linux README

## Testing
- `bash -n scripts/linux/check_dependencies.sh`
- `bash scripts/linux/check_dependencies.sh --help`
- `bash scripts/linux/check_dependencies.sh --install --dry-run --prefix /tmp/local`
- `shellcheck scripts/linux/check_dependencies.sh` *(fails: command not found)*


------
https://chatgpt.com/codex/tasks/task_e_689dcdee45788332915a6db85de5d36c