### PR TITLE
feat: make dependencies configurable

### DIFF
--- a/scripts/linux/README.md
+++ b/scripts/linux/README.md
@@ -2,7 +2,7 @@
 
 Ce dossier regroupe les scripts destinés aux systèmes GNU/Linux.
 
-- `check_dependencies.sh` – vérifie la présence des outils requis et peut tenter de les installer avec l'option `--install` (compatible avec `apt-get`, `yum`, `dnf` et `pacman`).
+- `check_dependencies.sh` – vérifie la présence des outils requis et peut tenter de les installer avec l'option `--install` (compatible avec `apt-get`, `yum`, `dnf` et `pacman`). Les listes de dépendances peuvent être adaptées dans `dependencies.conf`.
 - `setup_api.sh` – installe et configure l'API Mistral.
 - `pentest_discovery.sh` – phase de découverte lors d'un pentest.
 - `pentest_verification.sh` – vérification des vulnérabilités détectées.

--- a/scripts/linux/check_dependencies.sh
+++ b/scripts/linux/check_dependencies.sh
@@ -58,11 +58,16 @@ install_package() {
     fi
 }
 
-# Outils en ligne de commande requis
-CLI_DEPS=(nmap gvm-cli pwsh)
-
-# Modules PowerShell à vérifier
-PS_MODULES=("Hyper-V" "ExchangeOnlineManagement" "MicrosoftTeams" "PnP.PowerShell")
+# Chargement de la configuration des dépendances
+CONFIG_FILE="${CONFIG_FILE:-$(dirname "$0")/dependencies.conf}"
+if [[ -f "$CONFIG_FILE" ]]; then
+    # shellcheck source=/dev/null
+    source "$CONFIG_FILE"
+else
+    # Valeurs par défaut si aucun fichier n'est trouvé
+    CLI_DEPS=(nmap gvm-cli pwsh)
+    PS_MODULES=("Hyper-V" "ExchangeOnlineManagement" "MicrosoftTeams" "PnP.PowerShell")
+fi
 
 missing=0
 

--- a/scripts/linux/dependencies.conf
+++ b/scripts/linux/dependencies.conf
@@ -1,0 +1,6 @@
+# Default dependency configuration for check_dependencies.sh
+# CLI tools required
+CLI_DEPS=(nmap gvm-cli pwsh)
+
+# PowerShell modules to check
+PS_MODULES=("Hyper-V" "ExchangeOnlineManagement" "MicrosoftTeams" "PnP.PowerShell")


### PR DESCRIPTION
## Summary
- allow `check_dependencies.sh` to load dependency lists from a configurable `dependencies.conf`
- document configurable dependency file

## Testing
- `bash scripts/linux/check_dependencies.sh --help`
- `bash scripts/linux/check_dependencies.sh`

------
https://chatgpt.com/codex/tasks/task_e_689dd436e97c83328242c02d97f94762