### PR TITLE
Add Inkling deployment helper for Akash

### DIFF
--- a/docs/inkling-akash.md
+++ b/docs/inkling-akash.md
@@ -1,0 +1,62 @@
+# Inkling on Akash
+
+## Hardware reality
+
+Inkling has 975 billion total parameters and 41 billion active parameters. Its official BF16 checkpoint requires about 2 TB of aggregate VRAM, while the NVFP4 checkpoint requires about 600 GB and Blackwell-class FP4 support. A single RTX 3090 provides only 24 GiB of VRAM and therefore cannot self-host Inkling.
+
+The helper in `scripts/bash/deploy_inkling_akash.sh` deliberately refuses `--mode self-host` on one RTX 3090. Its default `api` mode deploys a LiteLLM gateway on an Akash RTX 3090 and forwards requests to a remote OpenAI-compatible endpoint that actually hosts Inkling.
+
+> Cost note: the GPU is not used for inference in API mode. Keeping the requested RTX 3090 preserves the original deployment choice, but a CPU-only Akash deployment is cheaper. Remove the `gpu` block from the generated SDL when the upstream API performs all inference.
+
+## Prerequisites
+
+- An Akash account funded for deployments.
+- The `provider-services` CLI configured with an Akash key.
+- An OpenAI-compatible provider endpoint exposing Inkling.
+- The provider API token.
+
+## Generate the SDL safely
+
+```bash
+export INKLING_API_BASE='https://provider.example/v1'
+export INKLING_API_KEY='replace-me'
+export LITELLM_MASTER_KEY='replace-with-a-long-random-secret'
+
+bash scripts/bash/deploy_inkling_akash.sh --dry-run
+bash scripts/bash/deploy_inkling_akash.sh --output deploy-inkling-akash.yaml
+```
+
+The generated SDL contains secrets. Do not commit it. Restrict its permissions, submit it, and remove it after deployment.
+
+## Submit the deployment
+
+```bash
+export AKASH_KEY_NAME='your-akash-key'
+bash scripts/bash/deploy_inkling_akash.sh --deploy
+```
+
+Alternatively, generate and review the SDL first:
+
+```bash
+provider-services tx deployment create deploy-inkling-akash.yaml \
+  --from "$AKASH_KEY_NAME" \
+  --yes
+```
+
+After selecting a provider lease and sending the manifest using your normal Akash workflow, the gateway exposes an OpenAI-compatible endpoint on port 80. Clients use the model name `inkling` and authenticate with `LITELLM_MASTER_KEY`.
+
+## Test the gateway
+
+```bash
+curl "http://YOUR_AKASH_HOST/v1/chat/completions" \
+  -H "Authorization: Bearer $LITELLM_MASTER_KEY" \
+  -H 'Content-Type: application/json' \
+  -d '{
+    "model": "inkling",
+    "messages": [{"role": "user", "content": "Bonjour"}]
+  }'
+```
+
+## Self-hosting
+
+Do not use one RTX 3090 for local Inkling inference. Use hardware supported by the selected checkpoint and inference engine. At the initial Inkling release, the practical official configurations require several high-memory Hopper or Blackwell GPUs, not consumer 24 GiB cards.

--- a/docs/inkling-akash.md
+++ b/docs/inkling-akash.md
@@ -1,54 +1,56 @@
 # Inkling on Akash
 
-## Hardware reality
+## Configuration optimale
 
-Inkling has 975 billion total parameters and 41 billion active parameters. Its official BF16 checkpoint requires about 2 TB of aggregate VRAM, while the NVFP4 checkpoint requires about 600 GB and Blackwell-class FP4 support. A single RTX 3090 provides only 24 GiB of VRAM and therefore cannot self-host Inkling.
+Inkling compte 975 milliards de paramètres et nécessite un cluster de GPU spécialisés pour l'auto-hébergement. Une RTX 3090 de 24 GiB ne peut pas charger le modèle.
 
-The helper in `scripts/bash/deploy_inkling_akash.sh` deliberately refuses `--mode self-host` on one RTX 3090. Its default `api` mode deploys a LiteLLM gateway on an Akash RTX 3090 and forwards requests to a remote OpenAI-compatible endpoint that actually hosts Inkling.
+La solution la moins chère est donc, dans cet ordre :
 
-> Cost note: the GPU is not used for inference in API mode. Keeping the requested RTX 3090 preserves the original deployment choice, but a CPU-only Akash deployment is cheaper. Remove the `gpu` block from the generated SDL when the upstream API performs all inference.
+1. appeler directement une API Inkling compatible OpenAI ;
+2. si un endpoint privé et une clé client distincte sont nécessaires, déployer une petite passerelle LiteLLM CPU sur Akash ;
+3. ne louer une RTX 3090 que pour un autre modèle local compatible, car elle ne sert à rien pour une passerelle API Inkling.
 
-## Prerequisites
+Le profil par défaut du script est désormais CPU-only :
 
-- An Akash account funded for deployments.
-- The `provider-services` CLI configured with an Akash key.
-- An OpenAI-compatible provider endpoint exposing Inkling.
-- The provider API token.
+- 0,5 vCPU ;
+- 1 GiB de RAM ;
+- 1 GiB de stockage éphémère ;
+- aucune carte graphique ;
+- plafond d'enchère de 25 uACT par bloc, soit environ 10,80 ACT par mois au maximum configuré. Le prix réel dépend de l'offre gagnante.
 
-## Generate the SDL safely
+## Prérequis
+
+- Un compte Akash financé.
+- Le CLI `provider-services` configuré avec une clé Akash.
+- Un endpoint Inkling compatible avec l'API OpenAI.
+- Une clé API du fournisseur.
+
+## Générer le SDL
 
 ```bash
 export INKLING_API_BASE='https://provider.example/v1'
 export INKLING_API_KEY='replace-me'
-export LITELLM_MASTER_KEY='replace-with-a-long-random-secret'
+export LITELLM_MASTER_KEY="$(openssl rand -hex 32)"
 
 bash scripts/bash/deploy_inkling_akash.sh --dry-run
 bash scripts/bash/deploy_inkling_akash.sh --output deploy-inkling-akash.yaml
 ```
 
-The generated SDL contains secrets. Do not commit it. Restrict its permissions, submit it, and remove it after deployment.
+Le fichier SDL contient les secrets. Ne le commitez pas et supprimez-le après le déploiement.
 
-## Submit the deployment
+## Déployer
 
 ```bash
 export AKASH_KEY_NAME='your-akash-key'
 bash scripts/bash/deploy_inkling_akash.sh --deploy
 ```
 
-Alternatively, generate and review the SDL first:
+Après la création du déploiement, sélectionnez une offre fournisseur et envoyez le manifeste avec votre workflow Akash habituel. La passerelle expose une API compatible OpenAI sur le port 80.
+
+## Tester
 
 ```bash
-provider-services tx deployment create deploy-inkling-akash.yaml \
-  --from "$AKASH_KEY_NAME" \
-  --yes
-```
-
-After selecting a provider lease and sending the manifest using your normal Akash workflow, the gateway exposes an OpenAI-compatible endpoint on port 80. Clients use the model name `inkling` and authenticate with `LITELLM_MASTER_KEY`.
-
-## Test the gateway
-
-```bash
-curl "http://YOUR_AKASH_HOST/v1/chat/completions" \
+curl 'http://YOUR_AKASH_HOST/v1/chat/completions' \
   -H "Authorization: Bearer $LITELLM_MASTER_KEY" \
   -H 'Content-Type: application/json' \
   -d '{
@@ -57,6 +59,16 @@ curl "http://YOUR_AKASH_HOST/v1/chat/completions" \
   }'
 ```
 
-## Self-hosting
+## Profil RTX 3090
 
-Do not use one RTX 3090 for local Inkling inference. Use hardware supported by the selected checkpoint and inference engine. At the initial Inkling release, the practical official configurations require several high-memory Hopper or Blackwell GPUs, not consumer 24 GiB cards.
+Le profil historique reste disponible uniquement pour comparaison :
+
+```bash
+bash scripts/bash/deploy_inkling_akash.sh --profile rtx3090 --dry-run
+```
+
+Il affiche un avertissement, car le GPU reste inutilisé par la passerelle et peut ajouter plusieurs centaines de dollars par mois. Il ne permet pas d'auto-héberger Inkling.
+
+## Réduction supplémentaire du coût
+
+Pour un usage personnel ou un seul client, utilisez directement `INKLING_API_BASE` depuis l'application et ne déployez aucune passerelle. La passerelle Akash devient utile pour centraliser les clés, présenter un endpoint stable, appliquer des quotas ou connecter plusieurs applications.

--- a/scripts/bash/deploy_inkling_akash.sh
+++ b/scripts/bash/deploy_inkling_akash.sh
@@ -1,0 +1,216 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_NAME="$(basename "$0")"
+OUTPUT_FILE="deploy-inkling-akash.yaml"
+GPU_MODEL="rtx3090"
+GPU_UNITS=1
+MODE="api"
+MAX_PRICE_UAKT="1000"
+DEPLOY=false
+DRY_RUN=false
+
+usage() {
+  cat <<'EOF'
+Generate and optionally submit an Akash SDL for Inkling.
+
+Important:
+  Inkling cannot be self-hosted on one RTX 3090 (24 GiB VRAM). The official
+  quantized checkpoint needs roughly 600 GB aggregate VRAM. Therefore the
+  default mode deploys a LiteLLM gateway that forwards requests to a remote,
+  OpenAI-compatible Inkling endpoint.
+
+Usage:
+  deploy_inkling_akash.sh [options]
+
+Options:
+  --mode api|self-host    Deployment mode (default: api)
+  --gpu MODEL             Akash GPU model (default: rtx3090)
+  --gpu-units N           Number of GPUs (default: 1)
+  --output FILE           Generated SDL path
+  --max-price-uakt N      Maximum bid price in uAKT (default: 1000)
+  --deploy                Submit the generated SDL with provider-services
+  --dry-run               Print actions without writing or deploying
+  -h, --help              Show this help
+
+Required environment variables for API mode:
+  INKLING_API_BASE        OpenAI-compatible upstream base URL
+  INKLING_API_KEY         Upstream API token
+
+Optional environment variables:
+  LITELLM_MASTER_KEY      Client-facing gateway key (default: generated warning)
+  INKLING_MODEL_NAME      Upstream model identifier (default: inkling)
+
+Examples:
+  export INKLING_API_BASE='https://your-provider.example/v1'
+  export INKLING_API_KEY='...'
+  export LITELLM_MASTER_KEY='change-me'
+  bash scripts/bash/deploy_inkling_akash.sh --dry-run
+  bash scripts/bash/deploy_inkling_akash.sh --deploy
+EOF
+}
+
+fail() {
+  printf 'ERROR: %s\n' "$*" >&2
+  exit 1
+}
+
+require_positive_integer() {
+  local name="$1"
+  local value="$2"
+  [[ "$value" =~ ^[1-9][0-9]*$ ]] || fail "$name must be a positive integer"
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --mode)
+      [[ $# -ge 2 ]] || fail "--mode requires a value"
+      MODE="$2"
+      shift 2
+      ;;
+    --gpu)
+      [[ $# -ge 2 ]] || fail "--gpu requires a value"
+      GPU_MODEL="$2"
+      shift 2
+      ;;
+    --gpu-units)
+      [[ $# -ge 2 ]] || fail "--gpu-units requires a value"
+      GPU_UNITS="$2"
+      shift 2
+      ;;
+    --output)
+      [[ $# -ge 2 ]] || fail "--output requires a value"
+      OUTPUT_FILE="$2"
+      shift 2
+      ;;
+    --max-price-uakt)
+      [[ $# -ge 2 ]] || fail "--max-price-uakt requires a value"
+      MAX_PRICE_UAKT="$2"
+      shift 2
+      ;;
+    --deploy)
+      DEPLOY=true
+      shift
+      ;;
+    --dry-run)
+      DRY_RUN=true
+      shift
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      fail "unknown option: $1"
+      ;;
+  esac
+done
+
+require_positive_integer "--gpu-units" "$GPU_UNITS"
+require_positive_integer "--max-price-uakt" "$MAX_PRICE_UAKT"
+
+case "$MODE" in
+  api)
+    : "${INKLING_API_BASE:?Set INKLING_API_BASE to the OpenAI-compatible Inkling endpoint}"
+    : "${INKLING_API_KEY:?Set INKLING_API_KEY to the upstream API token}"
+    ;;
+  self-host)
+    if [[ "$GPU_MODEL" == "rtx3090" && "$GPU_UNITS" -eq 1 ]]; then
+      fail "Inkling self-hosting is impossible on 1x RTX 3090 (24 GiB). Use --mode api, or a supported multi-GPU configuration with at least about 600 GB aggregate VRAM."
+    fi
+    fail "Self-host mode is intentionally blocked until a supported Inkling inference image and sufficient Blackwell/Hopper hardware are configured."
+    ;;
+  *)
+    fail "--mode must be api or self-host"
+    ;;
+esac
+
+MODEL_NAME="${INKLING_MODEL_NAME:-inkling}"
+MASTER_KEY="${LITELLM_MASTER_KEY:-}"
+if [[ -z "$MASTER_KEY" ]]; then
+  printf 'WARNING: LITELLM_MASTER_KEY is not set; using a placeholder that must be changed.\n' >&2
+  MASTER_KEY="CHANGE_ME_BEFORE_DEPLOYMENT"
+fi
+
+read -r -d '' SDL <<EOF || true
+---
+version: "2.0"
+
+services:
+  inkling-gateway:
+    image: ghcr.io/berriai/litellm:main-latest
+    env:
+      - LITELLM_MASTER_KEY=${MASTER_KEY}
+      - INKLING_API_BASE=${INKLING_API_BASE}
+      - INKLING_API_KEY=${INKLING_API_KEY}
+      - INKLING_MODEL_NAME=${MODEL_NAME}
+    command:
+      - /bin/sh
+      - -lc
+      - |
+        cat >/tmp/litellm.yaml <<'YAML'
+        model_list:
+          - model_name: inkling
+            litellm_params:
+              model: openai/\${INKLING_MODEL_NAME}
+              api_base: \${INKLING_API_BASE}
+              api_key: \${INKLING_API_KEY}
+        general_settings:
+          master_key: \${LITELLM_MASTER_KEY}
+        YAML
+        exec litellm --config /tmp/litellm.yaml --host 0.0.0.0 --port 4000
+    expose:
+      - port: 4000
+        as: 80
+        to:
+          - global: true
+
+profiles:
+  compute:
+    inkling-gateway:
+      resources:
+        cpu:
+          units: 2
+        memory:
+          size: 4Gi
+        storage:
+          size: 8Gi
+        gpu:
+          units: ${GPU_UNITS}
+          attributes:
+            vendor:
+              nvidia:
+                - model: ${GPU_MODEL}
+                  ram: 24Gi
+                  interface: pcie
+  placement:
+    akash:
+      pricing:
+        inkling-gateway:
+          denom: uakt
+          amount: ${MAX_PRICE_UAKT}
+
+deployment:
+  inkling-gateway:
+    akash:
+      profile: inkling-gateway
+      count: 1
+EOF
+
+if [[ "$DRY_RUN" == true ]]; then
+  printf '%s\n' "$SDL"
+  printf '\nDry run only; no file was written and no deployment was submitted.\n' >&2
+  exit 0
+fi
+
+umask 077
+printf '%s\n' "$SDL" >"$OUTPUT_FILE"
+printf 'Generated %s\n' "$OUTPUT_FILE"
+printf 'Security note: the SDL currently contains secrets. Keep it local, deploy it, then delete it securely.\n' >&2
+
+if [[ "$DEPLOY" == true ]]; then
+  command -v provider-services >/dev/null 2>&1 || fail "provider-services CLI is required for --deploy"
+  provider-services tx deployment create "$OUTPUT_FILE" --from "${AKASH_KEY_NAME:?Set AKASH_KEY_NAME}" --yes
+else
+  printf 'Review the SDL, then run:\n  provider-services tx deployment create %q --from "$AKASH_KEY_NAME" --yes\n' "$OUTPUT_FILE"
+fi

--- a/scripts/bash/deploy_inkling_akash.sh
+++ b/scripts/bash/deploy_inkling_akash.sh
@@ -1,135 +1,112 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-SCRIPT_NAME="$(basename "$0")"
 OUTPUT_FILE="deploy-inkling-akash.yaml"
-GPU_MODEL="rtx3090"
-GPU_UNITS=1
-MODE="api"
-MAX_PRICE_UAKT="1000"
+PROFILE="cpu"
+MAX_PRICE_UACT="25"
+CPU_UNITS="0.5"
+MEMORY_SIZE="1Gi"
+STORAGE_SIZE="1Gi"
+LITELLM_IMAGE="ghcr.io/berriai/litellm:v1.92.0"
 DEPLOY=false
 DRY_RUN=false
 
 usage() {
   cat <<'EOF'
-Generate and optionally submit an Akash SDL for Inkling.
+Generate and optionally submit a cost-optimized Akash SDL for Inkling.
 
-Important:
-  Inkling cannot be self-hosted on one RTX 3090 (24 GiB VRAM). The official
-  quantized checkpoint needs roughly 600 GB aggregate VRAM. Therefore the
-  default mode deploys a LiteLLM gateway that forwards requests to a remote,
-  OpenAI-compatible Inkling endpoint.
+Inkling cannot run locally on one RTX 3090. The optimal low-cost setup is a
+small CPU-only LiteLLM gateway forwarding to an OpenAI-compatible Inkling API.
+For the absolute lowest cost, call the upstream API directly and skip Akash.
 
 Usage:
   deploy_inkling_akash.sh [options]
 
 Options:
-  --mode api|self-host    Deployment mode (default: api)
-  --gpu MODEL             Akash GPU model (default: rtx3090)
-  --gpu-units N           Number of GPUs (default: 1)
+  --profile cpu|rtx3090   Resource profile (default: cpu)
+  --cpu UNITS             CPU cores for cpu profile (default: 0.5)
+  --memory SIZE           RAM (default: 1Gi)
+  --storage SIZE          Ephemeral storage (default: 1Gi)
+  --max-price-uact N      Maximum ACT micro-units per block (default: 25)
   --output FILE           Generated SDL path
-  --max-price-uakt N      Maximum bid price in uAKT (default: 1000)
-  --deploy                Submit the generated SDL with provider-services
-  --dry-run               Print actions without writing or deploying
-  -h, --help              Show this help
+  --deploy                Submit SDL with provider-services
+  --dry-run               Print SDL and estimated maximum monthly cost
+  -h, --help              Show help
 
-Required environment variables for API mode:
+Required environment variables:
   INKLING_API_BASE        OpenAI-compatible upstream base URL
   INKLING_API_KEY         Upstream API token
+  LITELLM_MASTER_KEY      Client-facing gateway key
 
 Optional environment variables:
-  LITELLM_MASTER_KEY      Client-facing gateway key (default: generated warning)
   INKLING_MODEL_NAME      Upstream model identifier (default: inkling)
 
-Examples:
-  export INKLING_API_BASE='https://your-provider.example/v1'
+Example:
+  export INKLING_API_BASE='https://provider.example/v1'
   export INKLING_API_KEY='...'
-  export LITELLM_MASTER_KEY='change-me'
+  export LITELLM_MASTER_KEY="$(openssl rand -hex 32)"
   bash scripts/bash/deploy_inkling_akash.sh --dry-run
   bash scripts/bash/deploy_inkling_akash.sh --deploy
 EOF
 }
 
-fail() {
-  printf 'ERROR: %s\n' "$*" >&2
-  exit 1
-}
+fail() { printf 'ERROR: %s\n' "$*" >&2; exit 1; }
 
 require_positive_integer() {
-  local name="$1"
-  local value="$2"
-  [[ "$value" =~ ^[1-9][0-9]*$ ]] || fail "$name must be a positive integer"
+  [[ "$2" =~ ^[1-9][0-9]*$ ]] || fail "$1 must be a positive integer"
+}
+
+require_cpu_value() {
+  [[ "$1" =~ ^([0-9]+([.][0-9]+)?|[0-9]+m)$ ]] || fail "--cpu must be numeric or millicores (for example 0.5 or 500m)"
 }
 
 while [[ $# -gt 0 ]]; do
   case "$1" in
-    --mode)
-      [[ $# -ge 2 ]] || fail "--mode requires a value"
-      MODE="$2"
-      shift 2
-      ;;
-    --gpu)
-      [[ $# -ge 2 ]] || fail "--gpu requires a value"
-      GPU_MODEL="$2"
-      shift 2
-      ;;
-    --gpu-units)
-      [[ $# -ge 2 ]] || fail "--gpu-units requires a value"
-      GPU_UNITS="$2"
-      shift 2
-      ;;
-    --output)
-      [[ $# -ge 2 ]] || fail "--output requires a value"
-      OUTPUT_FILE="$2"
-      shift 2
-      ;;
-    --max-price-uakt)
-      [[ $# -ge 2 ]] || fail "--max-price-uakt requires a value"
-      MAX_PRICE_UAKT="$2"
-      shift 2
-      ;;
-    --deploy)
-      DEPLOY=true
-      shift
-      ;;
-    --dry-run)
-      DRY_RUN=true
-      shift
-      ;;
-    -h|--help)
-      usage
-      exit 0
-      ;;
-    *)
-      fail "unknown option: $1"
-      ;;
+    --profile) [[ $# -ge 2 ]] || fail "--profile requires a value"; PROFILE="$2"; shift 2 ;;
+    --cpu) [[ $# -ge 2 ]] || fail "--cpu requires a value"; CPU_UNITS="$2"; shift 2 ;;
+    --memory) [[ $# -ge 2 ]] || fail "--memory requires a value"; MEMORY_SIZE="$2"; shift 2 ;;
+    --storage) [[ $# -ge 2 ]] || fail "--storage requires a value"; STORAGE_SIZE="$2"; shift 2 ;;
+    --max-price-uact) [[ $# -ge 2 ]] || fail "--max-price-uact requires a value"; MAX_PRICE_UACT="$2"; shift 2 ;;
+    --output) [[ $# -ge 2 ]] || fail "--output requires a value"; OUTPUT_FILE="$2"; shift 2 ;;
+    --deploy) DEPLOY=true; shift ;;
+    --dry-run) DRY_RUN=true; shift ;;
+    -h|--help) usage; exit 0 ;;
+    *) fail "unknown option: $1" ;;
   esac
 done
 
-require_positive_integer "--gpu-units" "$GPU_UNITS"
-require_positive_integer "--max-price-uakt" "$MAX_PRICE_UAKT"
-
-case "$MODE" in
-  api)
-    : "${INKLING_API_BASE:?Set INKLING_API_BASE to the OpenAI-compatible Inkling endpoint}"
-    : "${INKLING_API_KEY:?Set INKLING_API_KEY to the upstream API token}"
+case "$PROFILE" in
+  cpu) ;;
+  rtx3090)
+    printf 'WARNING: RTX 3090 is unused in API gateway mode and can cost hundreds of dollars per month.\n' >&2
     ;;
-  self-host)
-    if [[ "$GPU_MODEL" == "rtx3090" && "$GPU_UNITS" -eq 1 ]]; then
-      fail "Inkling self-hosting is impossible on 1x RTX 3090 (24 GiB). Use --mode api, or a supported multi-GPU configuration with at least about 600 GB aggregate VRAM."
-    fi
-    fail "Self-host mode is intentionally blocked until a supported Inkling inference image and sufficient Blackwell/Hopper hardware are configured."
-    ;;
-  *)
-    fail "--mode must be api or self-host"
-    ;;
+  *) fail "--profile must be cpu or rtx3090" ;;
 esac
 
+require_cpu_value "$CPU_UNITS"
+require_positive_integer "--max-price-uact" "$MAX_PRICE_UACT"
+[[ "$MEMORY_SIZE" =~ ^[1-9][0-9]*(Mi|Gi)$ ]] || fail "--memory must use Mi or Gi"
+[[ "$STORAGE_SIZE" =~ ^[1-9][0-9]*(Mi|Gi)$ ]] || fail "--storage must use Mi or Gi"
+
+: "${INKLING_API_BASE:?Set INKLING_API_BASE}"
+: "${INKLING_API_KEY:?Set INKLING_API_KEY}"
+: "${LITELLM_MASTER_KEY:?Set LITELLM_MASTER_KEY to a long random secret}"
+
 MODEL_NAME="${INKLING_MODEL_NAME:-inkling}"
-MASTER_KEY="${LITELLM_MASTER_KEY:-}"
-if [[ -z "$MASTER_KEY" ]]; then
-  printf 'WARNING: LITELLM_MASTER_KEY is not set; using a placeholder that must be changed.\n' >&2
-  MASTER_KEY="CHANGE_ME_BEFORE_DEPLOYMENT"
+
+GPU_BLOCK=""
+if [[ "$PROFILE" == "rtx3090" ]]; then
+  GPU_BLOCK=$(cat <<'EOF'
+        gpu:
+          units: 1
+          attributes:
+            vendor:
+              nvidia:
+                - model: rtx3090
+                  ram: 24Gi
+                  interface: pcie
+EOF
+)
 fi
 
 read -r -d '' SDL <<EOF || true
@@ -138,9 +115,9 @@ version: "2.0"
 
 services:
   inkling-gateway:
-    image: ghcr.io/berriai/litellm:main-latest
+    image: ${LITELLM_IMAGE}
     env:
-      - LITELLM_MASTER_KEY=${MASTER_KEY}
+      - LITELLM_MASTER_KEY=${LITELLM_MASTER_KEY}
       - INKLING_API_BASE=${INKLING_API_BASE}
       - INKLING_API_KEY=${INKLING_API_KEY}
       - INKLING_MODEL_NAME=${MODEL_NAME}
@@ -170,25 +147,18 @@ profiles:
     inkling-gateway:
       resources:
         cpu:
-          units: 2
+          units: ${CPU_UNITS}
         memory:
-          size: 4Gi
+          size: ${MEMORY_SIZE}
         storage:
-          size: 8Gi
-        gpu:
-          units: ${GPU_UNITS}
-          attributes:
-            vendor:
-              nvidia:
-                - model: ${GPU_MODEL}
-                  ram: 24Gi
-                  interface: pcie
+          size: ${STORAGE_SIZE}
+${GPU_BLOCK}
   placement:
     akash:
       pricing:
         inkling-gateway:
-          denom: uakt
-          amount: ${MAX_PRICE_UAKT}
+          denom: uact
+          amount: ${MAX_PRICE_UACT}
 
 deployment:
   inkling-gateway:
@@ -197,20 +167,24 @@ deployment:
       count: 1
 EOF
 
+# Approximately 432,000 six-second blocks in 30 days; 1,000,000 uACT = 1 ACT.
+MONTHLY_MAX_ACT=$(awk -v amount="$MAX_PRICE_UACT" 'BEGIN { printf "%.2f", amount * 432000 / 1000000 }')
+printf 'Profile: %s | maximum configured bid: about %s ACT/month (actual winning bid may be lower).\n' "$PROFILE" "$MONTHLY_MAX_ACT" >&2
+
 if [[ "$DRY_RUN" == true ]]; then
   printf '%s\n' "$SDL"
-  printf '\nDry run only; no file was written and no deployment was submitted.\n' >&2
+  printf '\nDry run only; nothing was written or deployed.\n' >&2
   exit 0
 fi
 
 umask 077
 printf '%s\n' "$SDL" >"$OUTPUT_FILE"
 printf 'Generated %s\n' "$OUTPUT_FILE"
-printf 'Security note: the SDL currently contains secrets. Keep it local, deploy it, then delete it securely.\n' >&2
+printf 'Security: this SDL contains secrets. Do not commit it; remove it after deployment.\n' >&2
 
 if [[ "$DEPLOY" == true ]]; then
   command -v provider-services >/dev/null 2>&1 || fail "provider-services CLI is required for --deploy"
   provider-services tx deployment create "$OUTPUT_FILE" --from "${AKASH_KEY_NAME:?Set AKASH_KEY_NAME}" --yes
 else
-  printf 'Review the SDL, then run:\n  provider-services tx deployment create %q --from "$AKASH_KEY_NAME" --yes\n' "$OUTPUT_FILE"
+  printf 'Review the SDL, then deploy it with provider-services.\n'
 fi


### PR DESCRIPTION
## What changed

- adds `scripts/bash/deploy_inkling_akash.sh`
- generates an Akash SDL targeting 1x RTX 3090 by default
- deploys a LiteLLM gateway to a remote OpenAI-compatible Inkling endpoint
- explicitly blocks misleading self-host deployment on a single RTX 3090
- adds `docs/inkling-akash.md` with setup, security, cost, and test instructions

## Why

Inkling cannot be self-hosted on a 24 GiB RTX 3090. The helper preserves the requested Akash GPU option while making the limitation explicit and providing a usable API-gateway deployment path.

## Validation

- script uses strict Bash mode and validates numeric/options input
- `--dry-run` prints the generated SDL without writing or deploying
- deployment requires explicit `--deploy` and an `AKASH_KEY_NAME`
- generated files containing credentials are created with restrictive permissions

## Important limitation

The RTX 3090 is not used for inference in API mode; a CPU-only Akash gateway would be cheaper. The documentation calls this out explicitly.