### PR TITLE
Integrate public CVE data into pentest scripts

### DIFF
--- a/docs/compatibility-matrix.md
+++ b/docs/compatibility-matrix.md
@@ -6,7 +6,7 @@
 | `scripts/linux/check_dependencies.sh` | Linux | Optional sudo for `--install` | package manager, optional `pwsh` | Low | Not needed |
 | `scripts/linux/setup_api.sh` | Debian/Ubuntu Linux | root | `apt-get`, `curl`, `python3`, network | Medium | `--offline` |
 | `scripts/linux/pentest_discovery.sh` | Linux | root recommended | `nmap` | High | Yes |
-| `scripts/linux/pentest_verification.sh` | Linux | root recommended | `nmap`, `msfconsole`, optional `gvm-cli` | High | Yes |
+| `scripts/linux/pentest_verification.sh` | Linux | root recommended | `nmap`, `msfconsole`, optional `gvm-cli`; Python 3 for public-data enrichment | High | Yes |
 | `scripts/linux/pentest_exploitation.sh` | Linux | depends on assessment | optional `searchsploit` | High | Yes |
 | `scripts/linux/scan_wifi.sh` | Linux | root | aircrack-ng suite | High | Yes |
 | `scripts/linux/stealth_post.sh` | Linux | user context | `gpg`, `curl`, `shred` | High | Yes |

--- a/scripts/linux/README.md
+++ b/scripts/linux/README.md
@@ -8,8 +8,8 @@ This directory contains Bash scripts for Linux administration, dependency checks
 - `dependencies.conf` - configurable list of CLI dependencies and PowerShell modules used by `check_dependencies.sh`.
 - `setup_api.sh` - installs and configures a local Mistral API environment.
 - `pentest_discovery.sh` - discovery phase for authorized security assessments.
-- `pentest_verification.sh` - verification phase for discovered findings.
-- `pentest_exploitation.sh` - exploitation phase for explicitly authorized tests.
+- `pentest_verification.sh` - verification phase, with optional public CVE enrichment.
+- `pentest_exploitation.sh` - prioritized SearchSploit review for explicitly authorized tests.
 - `scan_wifi.sh` - Wi-Fi scan helper with logging in `wifi_captures/scan_wifi.log`.
 - `stealth_post.sh` - encrypted FTPS transfer helper for authorized post-assessment collection.
 
@@ -40,6 +40,24 @@ Review a sensitive script without performing the action:
 bash pentest_discovery.sh --dry-run --yes-i-am-authorized
 bash scan_wifi.sh --dry-run --yes-i-am-authorized --non-interactive --bssid 00:11:22:33:44:55 --essid LabNetwork
 ```
+
+## Public vulnerability data
+
+The verification phase can enrich CVE identifiers found in both Nmap and OpenVAS XML. It queries the CISA Known Exploited Vulnerabilities catalog, NVD CVE API 2.0, and FIRST EPSS, then writes `<host>_cve_enrichment.tsv` and `.json` beside the scanner results. Only CVE identifiers are sent to NVD and FIRST; target addresses and scanner details remain local.
+
+```bash
+bash pentest_verification.sh \
+  --results ../../pentest_results/example \
+  --skip-metasploit \
+  --enrich-open-data \
+  --yes-i-am-authorized
+```
+
+Set `NVD_API_KEY` to use an NVD API key without placing it in arguments or logs. Responses are cached for 24 hours in `<results>/.open_data_cache`; use `--offline-enrichment` to prohibit network access and read only that cache. A source outage is non-fatal: the CVE list and any available source data are still written.
+
+Priorities are a review heuristic, not proof that a host is vulnerable or exploitable: CISA KEV entries are `critical`; EPSS >= 0.10 or CVSS >= 9.0 is `high`; EPSS >= 0.01 or CVSS >= 7.0 is `medium`; all others remain `review`. The exploitation helper consumes the TSV in that order but only generates SearchSploit suggestions.
+
+This product uses data from the NVD API but is not endorsed or certified by the NVD.
 
 Attempt dependency installation:
 

--- a/scripts/linux/pentest_exploitation.sh
+++ b/scripts/linux/pentest_exploitation.sh
@@ -99,10 +99,22 @@ else
     SEARCHSPLOIT_AVAILABLE=0
 fi
 
+append_suggestions() {
+    local host="$1"
+    local cve="$2"
+    local context="${3:-}"
+
+    [[ "$cve" =~ ^CVE-[0-9]{4}-[0-9]{4,}$ ]] || return 0
+    echo "## $host - $cve${context:+ ($context)}" >>"$SEARCH_FILE"
+    searchsploit "$cve" >>"$SEARCH_FILE" 2>/dev/null || true
+    echo >>"$SEARCH_FILE"
+}
+
 for xml in "$RESULTS_DIR"/*_vuln.xml; do
     [[ ! -f "$xml" ]] && continue
     host=$(basename "$xml" _vuln.xml)
     cve_file="$RESULTS_DIR/${host}_cves.list"
+    enrichment_file="$RESULTS_DIR/${host}_cve_enrichment.tsv"
 
     echo "[+] Exploitation review for $host"
     if [[ "$DRY_RUN" == true ]]; then
@@ -110,11 +122,15 @@ for xml in "$RESULTS_DIR"/*_vuln.xml; do
         continue
     fi
 
-    if [[ $SEARCHSPLOIT_AVAILABLE -eq 1 && -s "$cve_file" ]]; then
+    if [[ $SEARCHSPLOIT_AVAILABLE -eq 1 && -s "$enrichment_file" ]]; then
+        while IFS=$'\t' read -r cve priority kev kev_due ransomware epss percentile cvss severity _; do
+            [[ "$cve" == "cve" ]] && continue
+            context="priority=$priority, KEV=$kev, EPSS=${epss:-n/a}, CVSS=${cvss:-n/a}${severity:+/$severity}"
+            append_suggestions "$host" "$cve" "$context"
+        done <"$enrichment_file"
+    elif [[ $SEARCHSPLOIT_AVAILABLE -eq 1 && -s "$cve_file" ]]; then
         while IFS= read -r cve; do
-            echo "## $host - $cve" >>"$SEARCH_FILE"
-            searchsploit "$cve" >>"$SEARCH_FILE" 2>/dev/null || true
-            echo >>"$SEARCH_FILE"
+            append_suggestions "$host" "$cve"
         done <"$cve_file"
     else
         echo "    -> No CVE list or searchsploit unavailable."

--- a/scripts/linux/pentest_verification.sh
+++ b/scripts/linux/pentest_verification.sh
@@ -10,6 +10,9 @@ SUMMARY_FILE="$RESULTS_DIR/summary_vuln.log"
 DRY_RUN=false
 SKIP_OPENVAS=false
 SKIP_METASPLOIT=false
+ENRICH_OPEN_DATA=false
+OFFLINE_ENRICHMENT=false
+CACHE_DIR=""
 HOST_FILTERS=()
 RESULTS_DIR_SET=false
 ASSUME_AUTHORIZED="${SCRIPTING_ASSUME_AUTHORIZED:-false}"
@@ -22,6 +25,9 @@ Usage: $0 [options]
   --host host                Verify only this host; repeatable
   --skip-openvas             Do not try gvm-cli/OpenVAS
   --skip-metasploit          Do not run msfconsole modules
+  --enrich-open-data         Add CISA KEV, NVD and FIRST EPSS context
+  --offline-enrichment       Enrich only from an existing local cache
+  --open-data-cache dir      Override the public-data cache directory
   --dry-run                  Print planned verification commands
   --yes-i-am-authorized      Confirm you are allowed to test these hosts
   --help                     Show this help
@@ -79,6 +85,20 @@ while [[ $# -gt 0 ]]; do
             SKIP_METASPLOIT=true
             shift
             ;;
+        --enrich-open-data)
+            ENRICH_OPEN_DATA=true
+            shift
+            ;;
+        --offline-enrichment)
+            ENRICH_OPEN_DATA=true
+            OFFLINE_ENRICHMENT=true
+            shift
+            ;;
+        --open-data-cache)
+            need_value "$1" "${2:-}"
+            CACHE_DIR="$2"
+            shift 2
+            ;;
         --dry-run)
             DRY_RUN=true
             shift
@@ -97,11 +117,9 @@ while [[ $# -gt 0 ]]; do
 done
 
 require_authorization
-
 safe_filename() {
     printf '%s' "$1" | tr -c '[:alnum:]._-' '_'
 }
-
 has_discovery_xml() {
     local dir="$1"
     local xml
@@ -155,7 +173,9 @@ resolve_results_dir() {
 }
 
 resolve_results_dir
-
+if [[ -z "$CACHE_DIR" ]]; then
+    CACHE_DIR="$RESULTS_DIR/.open_data_cache"
+fi
 if [[ ! -d "$RESULTS_DIR" ]]; then
     if [[ "$DRY_RUN" == true ]]; then
         echo "DRY RUN: results directory does not exist yet: $RESULTS_DIR"
@@ -166,7 +186,6 @@ fi
 
 RUN_DIR="$RESULTS_DIR/verification_$(date +%Y%m%d_%H%M%S)"
 RUN_SUMMARY="$RUN_DIR/verification_summary.tsv"
-
 if [[ "$DRY_RUN" != true ]]; then
     mkdir -p "$RUN_DIR" || die "Unable to create verification run directory: $RUN_DIR"
     echo "Vulnerability summary - $(date)" > "$SUMMARY_FILE"
@@ -179,6 +198,10 @@ fi
 
 if [[ "$DRY_RUN" != true && "$SKIP_METASPLOIT" != true ]] && ! command -v msfconsole >/dev/null; then
     die "Missing required tool: msfconsole; re-run with --skip-metasploit to verify with nmap/OpenVAS only"
+fi
+
+if [[ "$DRY_RUN" != true && "$ENRICH_OPEN_DATA" == true ]] && ! command -v python3 >/dev/null; then
+    die "Missing required tool for open-data enrichment: python3"
 fi
 
 has_host_filter() {
@@ -200,6 +223,34 @@ record() {
     local detail="$4"
     echo "$host - $stage: $status ($detail)" >>"$SUMMARY_FILE"
     printf '%s\t%s\t%s\t%s\n' "$host" "$stage" "$status" "$detail" >>"$RUN_SUMMARY"
+}
+collect_and_enrich_cves() {
+    local host="$1"
+    local safe_host="$2"
+    local cve_file="$RESULTS_DIR/${safe_host}_cves.list"
+    local output_prefix="$RESULTS_DIR/${safe_host}_cve_enrichment"
+    local inputs=("$RESULTS_DIR/${safe_host}_vuln.xml")
+    local enrich_args=()
+
+    if [[ -f "$RESULTS_DIR/${safe_host}_openvas.xml" ]]; then
+        inputs+=("$RESULTS_DIR/${safe_host}_openvas.xml")
+    fi
+    { grep -hioE 'CVE-[0-9]{4}-[0-9]{4,}' "${inputs[@]}" || true; } | tr '[:lower:]' '[:upper:]' | sort -u >"$cve_file"
+    record "$host" "cve-extraction" "ok" "$cve_file"
+
+    if [[ "$ENRICH_OPEN_DATA" != true || ! -s "$cve_file" ]]; then
+        return 0
+    fi
+    if [[ "$OFFLINE_ENRICHMENT" == true ]]; then
+        enrich_args+=(--offline)
+    fi
+    if python3 "$REPO_ROOT/scripts/python/pentest_open_data.py" "$cve_file" \
+        --output-prefix "$output_prefix" --cache-dir "$CACHE_DIR" "${enrich_args[@]}"; then
+        record "$host" "open-data" "ok" "${output_prefix}.tsv"
+    else
+        record "$host" "open-data" "failed" "CVE list remains available at $cve_file"
+        echo "Open-data enrichment failed for $host; continuing with the local CVE list." >&2
+    fi
 }
 
 discover_entries() {
@@ -239,11 +290,11 @@ while IFS=$'\t' read -r host safe_host xml; do
     fi
     matched=$((matched + 1))
     echo "[+] Vulnerability verification for $host"
-
     if [[ -f "$RESULTS_DIR/${safe_host}_vuln.xml" ]]; then
         echo "Existing vulnerability result for $host, skipping."
         if [[ "$DRY_RUN" != true ]]; then
             record "$host" "nmap" "skipped" "existing vulnerability result"
+            collect_and_enrich_cves "$host" "$safe_host"
         fi
         continue
     fi
@@ -261,6 +312,9 @@ while IFS=$'\t' read -r host safe_host xml; do
         fi
         if [[ "$SKIP_METASPLOIT" != true ]]; then
             echo "DRY RUN: msfconsole -q -r \"$RUN_DIR/msfscan_${safe_host}.rc\""
+        fi
+        if [[ "$ENRICH_OPEN_DATA" == true ]]; then
+            echo "DRY RUN: extract CVEs from scanner XML and enrich them with CISA KEV, NVD and FIRST EPSS"
         fi
         ((count += 1))
         continue
@@ -299,14 +353,13 @@ while IFS=$'\t' read -r host safe_host xml; do
 
     if [[ -n "$openvas_pid" ]]; then
         if wait "$openvas_pid"; then
-            grep -oE 'CVE-[0-9]+-[0-9]+' "$OPENVAS_XML" | sort -u \
-                > "$RESULTS_DIR/${safe_host}_cves.list" || true
             record "$host" "openvas" "ok" "$OPENVAS_XML"
         else
             record "$host" "openvas" "failed" "$OPENVAS_XML"
-            continue
         fi
     fi
+
+    collect_and_enrich_cves "$host" "$safe_host"
 
     ((count += 1))
     if [[ "$SKIP_METASPLOIT" == true ]]; then

--- a/scripts/python/pentest_open_data.py
+++ b/scripts/python/pentest_open_data.py
@@ -1,0 +1,276 @@
+#!/usr/bin/env python3
+"""Enrich CVE identifiers with public defensive vulnerability data."""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import hashlib
+import json
+import os
+import re
+import sys
+import time
+import urllib.error
+import urllib.parse
+import urllib.request
+from dataclasses import asdict, dataclass
+from pathlib import Path
+from typing import Any, Iterable
+
+CVE_PATTERN = re.compile(r"\bCVE-\d{4}-\d{4,}\b", re.IGNORECASE)
+KEV_URL = "https://www.cisa.gov/sites/default/files/feeds/known_exploited_vulnerabilities.json"
+NVD_URL = "https://services.nvd.nist.gov/rest/json/cves/2.0"
+EPSS_URL = "https://api.first.org/data/v1/epss"
+USER_AGENT = "Scripting-pentest-open-data/1.0"
+MAX_INPUT_BYTES = 50 * 1024 * 1024
+MAX_RESPONSE_BYTES = 25 * 1024 * 1024
+MAX_CVES = 5_000
+
+
+@dataclass
+class Finding:
+    cve: str
+    priority: str = "review"
+    kev: bool = False
+    kev_due_date: str = ""
+    known_ransomware: str = ""
+    epss: float | None = None
+    epss_percentile: float | None = None
+    cvss: float | None = None
+    severity: str = ""
+    published: str = ""
+    description: str = ""
+
+
+class CachedJsonClient:
+    """Fetch fixed public JSON endpoints with a bounded local cache."""
+
+    def __init__(self, cache_dir: Path, ttl_seconds: int, offline: bool = False) -> None:
+        self.cache_dir = cache_dir
+        self.ttl_seconds = ttl_seconds
+        self.offline = offline
+
+    def get(self, url: str, headers: dict[str, str] | None = None) -> Any:
+        cache_path = self.cache_dir / f"{hashlib.sha256(url.encode()).hexdigest()}.json"
+        if cache_path.is_file():
+            age = time.time() - cache_path.stat().st_mtime
+            if self.offline or age <= self.ttl_seconds:
+                return self._read(cache_path)
+
+        if self.offline:
+            raise RuntimeError(f"cache absent pour {url}")
+
+        request_headers = {"Accept": "application/json", "User-Agent": USER_AGENT}
+        request_headers.update(headers or {})
+        request = urllib.request.Request(url, headers=request_headers)
+        try:
+            with urllib.request.urlopen(request, timeout=20) as response:
+                raw_payload = response.read(MAX_RESPONSE_BYTES + 1)
+                if len(raw_payload) > MAX_RESPONSE_BYTES:
+                    raise ValueError("réponse JSON trop volumineuse")
+                payload = json.loads(raw_payload)
+        except (OSError, ValueError, urllib.error.URLError) as exc:
+            if cache_path.is_file():
+                print(f"Avertissement: source indisponible, cache périmé utilisé: {exc}", file=sys.stderr)
+                return self._read(cache_path)
+            raise RuntimeError(f"échec de la source {url}: {exc}") from exc
+
+        if not isinstance(payload, dict):
+            raise RuntimeError(f"réponse JSON inattendue pour {url}")
+        self.cache_dir.mkdir(parents=True, exist_ok=True)
+        temporary = cache_path.with_suffix(".tmp")
+        temporary.write_text(json.dumps(payload), encoding="utf-8")
+        temporary.replace(cache_path)
+        return payload
+
+    @staticmethod
+    def _read(path: Path) -> Any:
+        try:
+            if path.stat().st_size > MAX_RESPONSE_BYTES:
+                raise ValueError("cache trop volumineux")
+            payload = json.loads(path.read_text(encoding="utf-8"))
+            if not isinstance(payload, dict):
+                raise ValueError("objet JSON attendu")
+            return payload
+        except (OSError, ValueError) as exc:
+            raise RuntimeError(f"cache illisible {path}: {exc}") from exc
+
+
+def extract_cves(paths: Iterable[Path]) -> list[str]:
+    found: set[str] = set()
+    for path in paths:
+        if not path.is_file():
+            raise ValueError(f"fichier introuvable: {path}")
+        if path.stat().st_size > MAX_INPUT_BYTES:
+            raise ValueError(f"fichier trop volumineux (limite 50 Mio): {path}")
+        text = path.read_text(encoding="utf-8", errors="replace")
+        found.update(match.upper() for match in CVE_PATTERN.findall(text))
+        if len(found) > MAX_CVES:
+            raise ValueError(f"plus de {MAX_CVES} CVE détectées; réduisez le périmètre")
+    return sorted(found)
+
+
+def chunks(values: list[str], maximum: int) -> Iterable[list[str]]:
+    for index in range(0, len(values), maximum):
+        yield values[index : index + maximum]
+
+
+def epss_chunks(values: list[str]) -> Iterable[list[str]]:
+    current: list[str] = []
+    current_length = 0
+    for value in values:
+        added = len(value) + (1 if current else 0)
+        if current and current_length + added > 2_000:
+            yield current
+            current, current_length = [], 0
+        current.append(value)
+        current_length += added
+    if current:
+        yield current
+
+
+def apply_kev(findings: dict[str, Finding], payload: dict[str, Any]) -> None:
+    for item in payload.get("vulnerabilities", []):
+        cve = str(item.get("cveID", "")).upper()
+        if cve in findings:
+            finding = findings[cve]
+            finding.kev = True
+            finding.kev_due_date = str(item.get("dueDate", ""))
+            finding.known_ransomware = str(item.get("knownRansomwareCampaignUse", ""))
+
+
+def _preferred_cvss(metrics: dict[str, Any]) -> tuple[float | None, str]:
+    for name in ("cvssMetricV40", "cvssMetricV31", "cvssMetricV30", "cvssMetricV2"):
+        entries = metrics.get(name) or []
+        if not entries:
+            continue
+        data = entries[0].get("cvssData", {})
+        score = data.get("baseScore")
+        severity = data.get("baseSeverity") or entries[0].get("baseSeverity") or ""
+        try:
+            return float(score), str(severity).upper()
+        except (TypeError, ValueError):
+            continue
+    return None, ""
+
+
+def apply_nvd(findings: dict[str, Finding], payload: dict[str, Any]) -> None:
+    for wrapper in payload.get("vulnerabilities", []):
+        item = wrapper.get("cve", {})
+        cve = str(item.get("id", "")).upper()
+        if cve not in findings:
+            continue
+        finding = findings[cve]
+        finding.cvss, finding.severity = _preferred_cvss(item.get("metrics", {}))
+        finding.published = str(item.get("published", ""))
+        descriptions = item.get("descriptions", [])
+        english = next((entry for entry in descriptions if entry.get("lang") == "en"), None)
+        selected = english or (descriptions[0] if descriptions else {})
+        finding.description = " ".join(str(selected.get("value", "")).split())
+
+
+def apply_epss(findings: dict[str, Finding], payload: dict[str, Any]) -> None:
+    for item in payload.get("data", []):
+        cve = str(item.get("cve", "")).upper()
+        if cve not in findings:
+            continue
+        try:
+            findings[cve].epss = float(item["epss"])
+            findings[cve].epss_percentile = float(item["percentile"])
+        except (KeyError, TypeError, ValueError):
+            continue
+
+
+def assign_priority(finding: Finding) -> None:
+    if finding.kev:
+        finding.priority = "critical"
+    elif (finding.epss or 0) >= 0.10 or (finding.cvss or 0) >= 9.0:
+        finding.priority = "high"
+    elif (finding.epss or 0) >= 0.01 or (finding.cvss or 0) >= 7.0:
+        finding.priority = "medium"
+    else:
+        finding.priority = "review"
+
+
+def enrich(cves: list[str], client: CachedJsonClient, nvd_api_key: str = "") -> list[Finding]:
+    findings = {cve: Finding(cve=cve) for cve in cves}
+    requests: list[tuple[str, str, list[list[str]] | None]] = [
+        ("CISA KEV", KEV_URL, None),
+        ("NVD", NVD_URL, list(chunks(cves, 100))),
+        ("FIRST EPSS", EPSS_URL, list(epss_chunks(cves))),
+    ]
+    for source, base_url, batches in requests:
+        try:
+            if batches is None:
+                apply_kev(findings, client.get(base_url))
+                continue
+            for batch in batches:
+                parameter = "cveIds" if source == "NVD" else "cve"
+                url = f"{base_url}?{urllib.parse.urlencode({parameter: ','.join(batch)})}"
+                headers = {"apiKey": nvd_api_key} if source == "NVD" and nvd_api_key else None
+                payload = client.get(url, headers)
+                if source == "NVD":
+                    apply_nvd(findings, payload)
+                else:
+                    apply_epss(findings, payload)
+        except RuntimeError as exc:
+            print(f"Avertissement: {source}: {exc}", file=sys.stderr)
+
+    for finding in findings.values():
+        assign_priority(finding)
+    order = {"critical": 0, "high": 1, "medium": 2, "review": 3}
+    return sorted(
+        findings.values(),
+        key=lambda item: (order[item.priority], -(item.epss or 0), -(item.cvss or 0), item.cve),
+    )
+
+
+def write_reports(findings: list[Finding], output_prefix: Path) -> tuple[Path, Path]:
+    output_prefix.parent.mkdir(parents=True, exist_ok=True)
+    tsv_path = Path(f"{output_prefix}.tsv")
+    json_path = Path(f"{output_prefix}.json")
+    fields = list(Finding.__dataclass_fields__)
+    with tsv_path.open("w", encoding="utf-8", newline="") as handle:
+        writer = csv.DictWriter(handle, fieldnames=fields, delimiter="\t", lineterminator="\n")
+        writer.writeheader()
+        writer.writerows(asdict(item) for item in findings)
+    json_path.write_text(
+        json.dumps([asdict(item) for item in findings], ensure_ascii=False, indent=2) + "\n",
+        encoding="utf-8",
+    )
+    return tsv_path, json_path
+
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("inputs", nargs="+", type=Path, help="XML, texte ou liste contenant des CVE")
+    parser.add_argument("--output-prefix", required=True, type=Path, help="préfixe des rapports .tsv et .json")
+    parser.add_argument("--cache-dir", type=Path, default=Path(".cache/pentest-open-data"))
+    parser.add_argument("--cache-ttl-hours", type=int, default=24)
+    parser.add_argument("--offline", action="store_true", help="interdire tout accès réseau")
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = parse_args(argv)
+    if args.cache_ttl_hours < 0:
+        print("Erreur: --cache-ttl-hours doit être positif", file=sys.stderr)
+        return 2
+    try:
+        cves = extract_cves(args.inputs)
+        if not cves:
+            print("Aucune CVE détectée dans les entrées.", file=sys.stderr)
+            return 0
+        client = CachedJsonClient(args.cache_dir, args.cache_ttl_hours * 3600, args.offline)
+        findings = enrich(cves, client, os.environ.get("NVD_API_KEY", ""))
+        tsv_path, json_path = write_reports(findings, args.output_prefix)
+    except (OSError, ValueError, RuntimeError) as exc:
+        print(f"Erreur: {exc}", file=sys.stderr)
+        return 1
+    print(f"{len(findings)} CVE enrichies: {tsv_path} et {json_path}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/python/pentest_open_data.py
+++ b/scripts/python/pentest_open_data.py
@@ -195,18 +195,17 @@ def assign_priority(finding: Finding) -> None:
 
 def enrich(cves: list[str], client: CachedJsonClient, nvd_api_key: str = "") -> list[Finding]:
     findings = {cve: Finding(cve=cve) for cve in cves}
-    requests: list[tuple[str, str, list[list[str]] | None]] = [
-        ("CISA KEV", KEV_URL, None),
-        ("NVD", NVD_URL, list(chunks(cves, 100))),
-        ("FIRST EPSS", EPSS_URL, list(epss_chunks(cves))),
+    requests: list[tuple[str, str, str, list[list[str]] | None]] = [
+        ("CISA KEV", KEV_URL, "", None),
+        ("NVD", NVD_URL, "cveId", list(chunks(cves, 1))),
+        ("FIRST EPSS", EPSS_URL, "cve", list(epss_chunks(cves))),
     ]
-    for source, base_url, batches in requests:
+    for source, base_url, parameter, batches in requests:
         try:
             if batches is None:
                 apply_kev(findings, client.get(base_url))
                 continue
             for batch in batches:
-                parameter = "cveIds" if source == "NVD" else "cve"
                 url = f"{base_url}?{urllib.parse.urlencode({parameter: ','.join(batch)})}"
                 headers = {"apiKey": nvd_api_key} if source == "NVD" and nvd_api_key else None
                 payload = client.get(url, headers)

--- a/scripts/python/tests/test_pentest_open_data.py
+++ b/scripts/python/tests/test_pentest_open_data.py
@@ -89,6 +89,50 @@ class PentestOpenDataTests(unittest.TestCase):
             ["critical", "high", "medium", "review"],
         )
 
+    def test_enrich_uses_nvd_cve_id_parameter(self):
+        class FakeClient:
+            def __init__(self):
+                self.calls = []
+
+            def get(self, url, headers=None):
+                self.calls.append((url, headers))
+                if url == OPEN_DATA.KEV_URL:
+                    return {"vulnerabilities": []}
+                if url.startswith(OPEN_DATA.NVD_URL):
+                    cve = url.rsplit("=", 1)[1]
+                    return {
+                        "vulnerabilities": [
+                            {
+                                "cve": {
+                                    "id": cve,
+                                    "metrics": {
+                                        "cvssMetricV31": [
+                                            {
+                                                "cvssData": {
+                                                    "baseScore": 9.1,
+                                                    "baseSeverity": "CRITICAL",
+                                                }
+                                            }
+                                        ]
+                                    },
+                                }
+                            }
+                        ]
+                    }
+                if url.startswith(OPEN_DATA.EPSS_URL):
+                    return {"data": []}
+                raise AssertionError(f"unexpected URL: {url}")
+
+        client = FakeClient()
+        findings = OPEN_DATA.enrich(["CVE-2024-1111", "CVE-2024-2222"], client, "secret")
+
+        nvd_calls = [call for call in client.calls if call[0].startswith(OPEN_DATA.NVD_URL)]
+        self.assertEqual(len(nvd_calls), 2)
+        self.assertTrue(all("cveId=CVE-" in url for url, _ in nvd_calls))
+        self.assertTrue(all("cveIds=" not in url for url, _ in nvd_calls))
+        self.assertTrue(all(headers == {"apiKey": "secret"} for _, headers in nvd_calls))
+        self.assertEqual([finding.cvss for finding in findings], [9.1, 9.1])
+
     def test_writes_machine_readable_reports(self):
         with tempfile.TemporaryDirectory() as temp_dir:
             prefix = Path(temp_dir) / "10.0.0.1_cve_enrichment"

--- a/scripts/python/tests/test_pentest_open_data.py
+++ b/scripts/python/tests/test_pentest_open_data.py
@@ -1,0 +1,105 @@
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+import sys
+import tempfile
+import unittest
+
+
+MODULE_PATH = Path(__file__).parents[1] / "pentest_open_data.py"
+SPEC = importlib.util.spec_from_file_location("pentest_open_data", MODULE_PATH)
+assert SPEC and SPEC.loader
+OPEN_DATA = importlib.util.module_from_spec(SPEC)
+sys.modules[SPEC.name] = OPEN_DATA
+SPEC.loader.exec_module(OPEN_DATA)
+
+
+class PentestOpenDataTests(unittest.TestCase):
+    def test_extracts_normalizes_and_deduplicates_cves(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            source = Path(temp_dir) / "scanner.xml"
+            source.write_text(
+                "<finding>CVE-2024-12345 cve-2024-12345 CVE-2023-9999</finding>",
+                encoding="utf-8",
+            )
+
+            self.assertEqual(
+                OPEN_DATA.extract_cves([source]),
+                ["CVE-2023-9999", "CVE-2024-12345"],
+            )
+
+    def test_combines_kev_nvd_and_epss_context(self):
+        finding = OPEN_DATA.Finding(cve="CVE-2024-12345")
+        findings = {finding.cve: finding}
+        OPEN_DATA.apply_kev(
+            findings,
+            {
+                "vulnerabilities": [
+                    {
+                        "cveID": finding.cve,
+                        "dueDate": "2026-08-15",
+                        "knownRansomwareCampaignUse": "Known",
+                    }
+                ]
+            },
+        )
+        OPEN_DATA.apply_nvd(
+            findings,
+            {
+                "vulnerabilities": [
+                    {
+                        "cve": {
+                            "id": finding.cve,
+                            "published": "2024-01-01T00:00:00Z",
+                            "descriptions": [{"lang": "en", "value": "Example\nissue"}],
+                            "metrics": {
+                                "cvssMetricV31": [
+                                    {"cvssData": {"baseScore": 8.8, "baseSeverity": "HIGH"}}
+                                ]
+                            },
+                        }
+                    }
+                ]
+            },
+        )
+        OPEN_DATA.apply_epss(
+            findings,
+            {"data": [{"cve": finding.cve, "epss": "0.42", "percentile": "0.95"}]},
+        )
+        OPEN_DATA.assign_priority(finding)
+
+        self.assertTrue(finding.kev)
+        self.assertEqual(finding.priority, "critical")
+        self.assertEqual(finding.cvss, 8.8)
+        self.assertEqual(finding.epss, 0.42)
+        self.assertEqual(finding.description, "Example issue")
+
+    def test_priority_heuristic_prefers_exploitation_then_probability(self):
+        kev = OPEN_DATA.Finding(cve="CVE-2024-1111", kev=True)
+        likely = OPEN_DATA.Finding(cve="CVE-2024-2222", epss=0.11)
+        severe = OPEN_DATA.Finding(cve="CVE-2024-3333", cvss=7.5)
+        unknown = OPEN_DATA.Finding(cve="CVE-2024-4444")
+
+        for finding in (kev, likely, severe, unknown):
+            OPEN_DATA.assign_priority(finding)
+
+        self.assertEqual(
+            [kev.priority, likely.priority, severe.priority, unknown.priority],
+            ["critical", "high", "medium", "review"],
+        )
+
+    def test_writes_machine_readable_reports(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            prefix = Path(temp_dir) / "10.0.0.1_cve_enrichment"
+            tsv_path, json_path = OPEN_DATA.write_reports(
+                [OPEN_DATA.Finding(cve="CVE-2024-12345", priority="high")], prefix
+            )
+
+            self.assertIn("cve\tpriority\tkev", tsv_path.read_text(encoding="utf-8"))
+            self.assertIn('"CVE-2024-12345"', json_path.read_text(encoding="utf-8"))
+            self.assertEqual(tsv_path.name, "10.0.0.1_cve_enrichment.tsv")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/tests/test-linux-safety.sh
+++ b/scripts/tests/test-linux-safety.sh
@@ -39,6 +39,10 @@ assert_ok "discovery dry-run" \
 assert_ok "verification dry-run" \
     bash scripts/linux/pentest_verification.sh --dry-run --yes-i-am-authorized >/dev/null 2>&1
 
+assert_ok "verification open-data dry-run" \
+    bash scripts/linux/pentest_verification.sh --dry-run --enrich-open-data \
+        --yes-i-am-authorized >/dev/null 2>&1
+
 assert_ok "exploitation dry-run" \
     bash scripts/linux/pentest_exploitation.sh --dry-run --yes-i-am-authorized >/dev/null 2>&1
 


### PR DESCRIPTION
### What Problem This Solves

Pentest verification results exposed CVE identifiers without combining current public exploitation, severity, and probability context. Reviewers had to query CISA KEV, NVD, and FIRST EPSS manually before prioritizing SearchSploit research.

### Why This Change Was Made

Add a standard-library Python enricher that extracts CVEs from Nmap and OpenVAS output, queries CISA KEV, NVD CVE API 2.0, and FIRST EPSS, and emits prioritized TSV and JSON reports. The integration includes bounded inputs and responses, a 24-hour cache, stale-cache fallback, offline operation, and partial results when one source is unavailable.

The verification script exposes opt-in enrichment flags, while the exploitation helper consumes the prioritized report only to generate SearchSploit suggestions. It does not automate exploitation.

### User Impact

Authorized assessment users can add `--enrich-open-data` to receive consolidated KEV, EPSS, and CVSS context beside scanner output. Only CVE identifiers are sent to NVD and FIRST; target addresses and scanner details remain local. Existing behavior remains unchanged unless enrichment is enabled.

### Evidence

- Before: Nmap and OpenVAS CVEs were written as a flat list with no public-data context or cross-source prioritization.
- Tests: `python -m unittest discover -s scripts/python/tests -p "test_*.py"` — 77 passed.
- Checks: Python compilation passed; Bash syntax checks passed; `scripts/tests/test-linux-safety.sh` passed; `git diff --check` passed.
- Smoke checks: live online enrichment and cache-only offline enrichment both produced TSV and JSON reports successfully.
- Autoreview: manual scope and diff review completed; no unrelated working-tree files included.
