### PR TITLE
Test CVE enrichment parsing across Python versions

### DIFF
--- a/.github/workflows/script-validation.yml
+++ b/.github/workflows/script-validation.yml
@@ -98,9 +98,13 @@ jobs:
         run: bash scripts/tests/test-linux-safety.sh
 
   python:
-    name: Python validation
+    name: Python ${{ matrix.python-version }} validation
     runs-on: windows-latest
     timeout-minutes: 10
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.11", "3.12"]
 
     steps:
       - name: Checkout
@@ -109,7 +113,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
-          python-version: "3.12"
+          python-version: ${{ matrix.python-version }}
 
       - name: Install Python test dependencies
         run: python -m pip install -r scripts/python/requirements.txt

--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,19 @@ logs/
 # Ignore Python cache files
 __pycache__/
 *.py[cod]
+.pytest_cache/
+.ruff_cache/
+.mypy_cache/
+.coverage
+.coverage.*
+htmlcov/
+.venv/
+venv/
+
+# Ignore local environment files, but keep templates tracked
+.env
+.env.*
+!.env.example
 
 # Ignore data files
 *.csv

--- a/scripts/linux/pentest_exploitation.sh
+++ b/scripts/linux/pentest_exploitation.sh
@@ -123,11 +123,15 @@ for xml in "$RESULTS_DIR"/*_vuln.xml; do
     fi
 
     if [[ $SEARCHSPLOIT_AVAILABLE -eq 1 && -s "$enrichment_file" ]]; then
-        while IFS=$'\t' read -r cve priority kev kev_due ransomware epss percentile cvss severity _; do
+        while IFS=$'\034' read -r cve priority kev kev_due ransomware epss percentile cvss severity; do
             [[ "$cve" == "cve" ]] && continue
             context="priority=$priority, KEV=$kev, EPSS=${epss:-n/a}, CVSS=${cvss:-n/a}${severity:+/$severity}"
             append_suggestions "$host" "$cve" "$context"
-        done <"$enrichment_file"
+        done < <(
+            awk -F '\t' -v OFS='\034' \
+                '{ print $1, $2, $3, $4, $5, $6, $7, $8, $9 }' \
+                "$enrichment_file"
+        )
     elif [[ $SEARCHSPLOIT_AVAILABLE -eq 1 && -s "$cve_file" ]]; then
         while IFS= read -r cve; do
             append_suggestions "$host" "$cve"

--- a/scripts/tests/test-linux-safety.sh
+++ b/scripts/tests/test-linux-safety.sh
@@ -18,6 +18,49 @@ assert_no_artifacts() {
     fi
 }
 
+assert_contains() {
+    local file="$1"
+    local expected="$2"
+    if ! grep -Fq "$expected" "$file"; then
+        echo "Expected '$expected' in $file" >&2
+        exit 1
+    fi
+}
+
+assert_exploitation_enrichment_context() {
+    local temp_root results_dir fake_bin search_file calls_file
+    temp_root="$(mktemp -d)"
+    results_dir="$temp_root/results"
+    fake_bin="$temp_root/bin"
+    search_file="$temp_root/suggestions.txt"
+    calls_file="$temp_root/searchsploit.calls"
+    mkdir -p "$results_dir" "$fake_bin"
+    trap '[[ "${temp_root:-}" == /tmp/* ]] && rm -rf "$temp_root"' RETURN
+
+    touch "$results_dir/10.0.0.5_vuln.xml"
+    cat >"$results_dir/10.0.0.5_cve_enrichment.tsv" <<'EOF'
+cve	priority	kev	kev_due_date	known_ransomware	epss	epss_percentile	cvss	severity	published	description
+CVE-2024-1111	critical	True	2026-08-15	Known	0.42	0.95	8.8	HIGH	2024-01-01	Example issue
+CVE-2024-2222	medium	False			0.02	0.50	7.1	HIGH	2024-02-01	Second issue
+EOF
+    cat >"$fake_bin/searchsploit" <<EOF
+#!/bin/bash
+echo "\$1" >>"$calls_file"
+echo "fake exploit for \$1"
+EOF
+    chmod +x "$fake_bin/searchsploit"
+
+    PATH="$fake_bin:$PATH" bash scripts/linux/pentest_exploitation.sh \
+        --results "$results_dir" \
+        --search-file "$search_file" \
+        --yes-i-am-authorized >/dev/null
+
+    assert_contains "$calls_file" "CVE-2024-1111"
+    assert_contains "$calls_file" "CVE-2024-2222"
+    assert_contains "$search_file" "priority=critical, KEV=True, EPSS=0.42, CVSS=8.8/HIGH"
+    assert_contains "$search_file" "priority=medium, KEV=False, EPSS=0.02, CVSS=7.1/HIGH"
+}
+
 SENSITIVE_SCRIPTS=(
     scripts/pentest_discovery.sh
     scripts/pentest_verification.sh
@@ -54,6 +97,8 @@ assert_ok "verification wrapper dry-run" \
 
 assert_ok "exploitation wrapper dry-run" \
     bash scripts/pentest_exploitation.sh --dry-run --yes-i-am-authorized >/dev/null 2>&1
+
+assert_ok "exploitation enrichment context" assert_exploitation_enrichment_context
 
 assert_ok "wifi dry-run" \
     bash scripts/linux/scan_wifi.sh --dry-run --yes-i-am-authorized --non-interactive \


### PR DESCRIPTION
## Summary
- preserve empty TSV fields when building CVE exploitation context
- add a regression test for KEV, EPSS, and CVSS metadata
- validate Python tooling on 3.11 and 3.12
- ignore common local Python and environment artifacts

## Validation
- git diff --check
- bash -n scripts/tests/test-linux-safety.sh scripts/linux/pentest_exploitation.sh
- bash scripts/tests/test-linux-safety.sh