### PR TITLE
Upgrade LiteLLM to 1.95 with auto routing

### DIFF
--- a/scripts/python/Install-CodexLocalLiteLLMAssets.ps1
+++ b/scripts/python/Install-CodexLocalLiteLLMAssets.ps1
@@ -1,6 +1,6 @@
 [CmdletBinding()]
 param(
-    [string]$LiteLLMVersion = '1.90.0',
+    [string]$LiteLLMVersion = '1.95.0',
     [switch]$SkipLiteLLMInstall
 )
 

--- a/scripts/python/Manage-CodexCostRouting.ps1
+++ b/scripts/python/Manage-CodexCostRouting.ps1
@@ -7,7 +7,7 @@ param(
     [ValidateSet('Standard', 'LiteLLM', 'HuggingFace')]
     [string]$CodexProvider = 'Standard',
     [switch]$UpdateLiteLLM,
-    [string]$LiteLLMVersion = '1.90.0'
+    [string]$LiteLLMVersion = '1.95.0'
 )
 
 $ErrorActionPreference = 'Stop'

--- a/scripts/python/README_Codex_Cost_Routing.md
+++ b/scripts/python/README_Codex_Cost_Routing.md
@@ -21,11 +21,14 @@ applies budgets, and selects one of these LiteLLM aliases:
   is set
 - `codex-hf-fast` for larger Hugging Face / multi-provider tasks when
   `HF_TOKEN` is set
+- `codex-inkling` for Thinking Machines Inkling through its OpenAI-compatible
+  ModelsLab endpoint when `INKLING_API_KEY` is set
 
 Gemini and local Qwen are configured through LiteLLM model groups when the proxy is active. Without the proxy, the wrapper keeps the standard Codex path and can still call local Qwen directly through Ollama for selected local tasks.
 
 Provider API keys are never committed or written to a configuration file.
-`GEMINI_API_KEY` is only needed for Gemini dispatch through LiteLLM. Local Qwen
+`GEMINI_API_KEY` is only needed for Gemini dispatch through LiteLLM, and
+`INKLING_API_KEY` enables the `codex-inkling` dispatch. Local Qwen
 only needs Ollama running with `qwen2.5-coder:3b` installed. The local proxy
 master key is generated per session and written only to
 `%TEMP%\codex-litellm-proxy.key` so local test scripts can authenticate; it is
@@ -401,6 +404,14 @@ the `codex-auto` alias:
 .\scripts\python\Test-CodexLiteLLMDispatch.ps1 -Model codex-auto -Call
 ```
 
+To dispatch explicitly to Inkling, export the provider key for the session and
+call the dedicated alias:
+
+```powershell
+$env:INKLING_API_KEY = "your-modelslab-key"
+.\scripts\python\Test-CodexLiteLLMDispatch.ps1 -Model codex-inkling -Call
+```
+
 The launcher automatically bypasses restrictive PowerShell execution policies
 for this command only. With no arguments, it opens the normal Codex CLI path:
 no LiteLLM proxy, no API-key prompt, no temporary Codex profile.
@@ -410,7 +421,7 @@ When `-CodexProvider LiteLLM` is selected, the script:
 1. installs the official LiteLLM OSS proxy in `C:\tmp\litellm-oss` when needed;
 2. can update the local LiteLLM package with `-Action Update` or `-UpdateLiteLLM`;
 3. asks only for optional session keys that are not already set;
-4. requires at least `OPENAI_API_KEY`, `GEMINI_API_KEY`, or local Qwen on Ollama;
+4. requires at least `OPENAI_API_KEY`, `GEMINI_API_KEY`, `INKLING_API_KEY`, or local Qwen on Ollama;
 5. creates a random local `LITELLM_API_KEY` for the proxy session and writes
    only that local proxy key to `%TEMP%\codex-litellm-proxy.key`;
 6. starts the LiteLLM proxy in the background;
@@ -427,7 +438,7 @@ If you prefer entering keys in a local page for one work session, start:
 ```
 
 Then open `http://127.0.0.1:8787/`, paste `OPENAI_API_KEY`,
-`GEMINI_API_KEY`, or `HF_TOKEN`, and submit the form. Qwen is not managed as an
+`GEMINI_API_KEY`, `HF_TOKEN`, or `INKLING_API_KEY`, and submit the form. Qwen is not managed as an
 API provider here: it is only an optional local Ollama fallback. Run
 `Start-CodexQwenOllama.ps1` and keep the local Qwen checkbox enabled; no Qwen API
 base or API key is accepted by the page. The page starts the LiteLLM proxy on

--- a/scripts/python/README_Codex_Cost_Routing.md
+++ b/scripts/python/README_Codex_Cost_Routing.md
@@ -13,6 +13,7 @@ applies budgets, and selects one of these LiteLLM aliases:
 - `codex-default` for normal coding work
 - `codex-long` for long-context reads, log review, and synthesis
 - `codex-deep` for difficult debugging, security, and architecture decisions
+- `codex-auto` for LiteLLM native complexity-based automatic routing
 - `codex-no-openai` for Gemini + local Qwen routing when OpenAI quota is low
   or exhausted
 - `codex-cheap` and `codex-strong` as backward-compatible aliases
@@ -376,11 +377,11 @@ codex --profile cost-routing
 ```
 
 Install or update the local LiteLLM OSS proxy to the currently pinned stable
-PyPI release. As of 2026-06-29 this repository pins `litellm==1.90.0`:
+PyPI release. As of 2026-08-07 this repository pins `litellm==1.95.0`:
 
 ```powershell
 .\scripts\python\Install-CodexLocalLiteLLMAssets.ps1
-.\scripts\python\Manage-CodexCostRouting.ps1 -Action Update -LiteLLMVersion 1.90.0
+.\scripts\python\Manage-CodexCostRouting.ps1 -Action Update -LiteLLMVersion 1.95.0
 .\scripts\python\Manage-CodexCostRouting.ps1 -Action Status
 ```
 
@@ -390,7 +391,14 @@ the pinned stable version after checking PyPI/release notes.
 You can also update while starting the proxy:
 
 ```powershell
-.\scripts\python\Manage-CodexCostRouting.ps1 -Action Start -CodexProvider LiteLLM -UpdateLiteLLM -LiteLLMVersion 1.90.0
+.\scripts\python\Manage-CodexCostRouting.ps1 -Action Start -CodexProvider LiteLLM -UpdateLiteLLM -LiteLLMVersion 1.95.0
+```
+
+To let LiteLLM classify request complexity and select the configured tier, use
+the `codex-auto` alias:
+
+```powershell
+.\scripts\python\Test-CodexLiteLLMDispatch.ps1 -Model codex-auto -Call
 ```
 
 The launcher automatically bypasses restrictive PowerShell execution policies

--- a/scripts/python/Test-CodexLiteLLMDispatch.ps1
+++ b/scripts/python/Test-CodexLiteLLMDispatch.ps1
@@ -53,7 +53,8 @@ $requiredAliases = @(
     "codex-deep",
     "codex-qwen-local",
     "codex-hf-cheap",
-    "codex-hf-fast"
+    "codex-hf-fast",
+    "codex-inkling"
 )
 $missingAliases = @($requiredAliases | Where-Object { $modelIds -notcontains $_ })
 

--- a/scripts/python/codex_key_session_web.py
+++ b/scripts/python/codex_key_session_web.py
@@ -188,7 +188,7 @@ PAGE = """<!doctype html>
       </div>
       <div class="meta">
         <div class="pill">Proxy URL: <code>http://127.0.0.1:{proxy_port}/v1</code></div>
-        <div class="pill">Codex model aliases: <code>codex-light</code>, <code>codex-default</code>, <code>codex-long</code>, <code>codex-deep</code></div>
+        <div class="pill">Codex model aliases: <code>codex-light</code>, <code>codex-default</code>, <code>codex-long</code>, <code>codex-deep</code>, <code>codex-inkling</code></div>
         <div class="pill">Local fallback: <code>codex-qwen-local</code></div>
       </div>
     </section>
@@ -202,6 +202,8 @@ PAGE = """<!doctype html>
         <input id="gemini" name="GEMINI_API_KEY" type="password" placeholder="AI..." autocomplete="off">
         <label for="hf">Hugging Face token optional</label>
         <input id="hf" name="HF_TOKEN" type="password" placeholder="hf_..." autocomplete="off">
+        <label for="inkling">Inkling API key optional</label>
+        <input id="inkling" name="INKLING_API_KEY" type="password" placeholder="Inkling / ModelsLab key" autocomplete="off">
         <label class="check" for="use_qwen">
           <input id="use_qwen" name="USE_LOCAL_QWEN" type="checkbox" value="1" checked>
           Enable local Qwen fallback through Ollama
@@ -321,8 +323,9 @@ class KeySessionHandler(BaseHTTPRequestHandler):
         openai_key = form.get("OPENAI_API_KEY", "")
         gemini_key = form.get("GEMINI_API_KEY", "")
         hf_token = form.get("HF_TOKEN", "")
+        inkling_key = form.get("INKLING_API_KEY", "")
         use_local_qwen = form.get("USE_LOCAL_QWEN", "") == "1"
-        if not any((openai_key, gemini_key, hf_token, use_local_qwen)):
+        if not any((openai_key, gemini_key, hf_token, inkling_key, use_local_qwen)):
             self.state.message = "Provide at least one provider key, or keep local Qwen enabled."
             self._send_page()
             return
@@ -339,6 +342,8 @@ class KeySessionHandler(BaseHTTPRequestHandler):
         if hf_token:
             env["HF_TOKEN"] = hf_token
             env["HUGGINGFACE_API_KEY"] = hf_token
+        if inkling_key:
+            env["INKLING_API_KEY"] = inkling_key
 
         try:
             self.state.process = subprocess.Popen(

--- a/scripts/python/litellm-cost-routing.yaml
+++ b/scripts/python/litellm-cost-routing.yaml
@@ -138,6 +138,18 @@ model_list:
       model: huggingface/together/openai/gpt-oss-120b
       api_key: os.environ/HF_TOKEN
 
+  - model_name: codex-auto
+    litellm_params:
+      model: auto_router/complexity_router
+      complexity_router_config:
+        tiers:
+          SIMPLE: codex-small-local
+          MEDIUM: codex-default
+          COMPLEX: codex-long
+          REASONING: codex-deep
+        session_affinity: true
+      complexity_router_default_model: codex-default
+
 router_settings:
   routing_strategy: simple-shuffle
   num_retries: 2
@@ -151,6 +163,9 @@ router_settings:
     gemini-2.5-pro: codex-long
     claude-sonnet: codex-claude-complex
   fallbacks:
+    - codex-auto:
+        - codex-default
+        - codex-qwen-local
     - codex-small-local:
         - codex-phi-local
         - codex-qwen-local

--- a/scripts/python/litellm-cost-routing.yaml
+++ b/scripts/python/litellm-cost-routing.yaml
@@ -138,6 +138,13 @@ model_list:
       model: huggingface/together/openai/gpt-oss-120b
       api_key: os.environ/HF_TOKEN
 
+  - model_name: codex-inkling
+    litellm_params:
+      model: openai/thinkingmachines-inkling
+      api_base: https://modelslab.com/api/v7/llm
+      api_key: os.environ/INKLING_API_KEY
+      weight: 1
+
   - model_name: codex-auto
     litellm_params:
       model: auto_router/complexity_router
@@ -162,6 +169,7 @@ router_settings:
     gemini-2.5-flash: codex-light
     gemini-2.5-pro: codex-long
     claude-sonnet: codex-claude-complex
+    thinkingmachines-inkling: codex-inkling
   fallbacks:
     - codex-auto:
         - codex-default
@@ -201,6 +209,10 @@ router_settings:
         - codex-light
         - codex-qwen-local
     - codex-hf-fast:
+        - codex-default
+        - codex-qwen-local
+    - codex-inkling:
+        - codex-deep
         - codex-default
         - codex-qwen-local
   context_window_fallbacks:

--- a/scripts/python/start-litellm-proxy.ps1
+++ b/scripts/python/start-litellm-proxy.ps1
@@ -8,7 +8,7 @@ $ErrorActionPreference = 'Stop'
 
 $root = 'C:\Users\user\.codex\litellm-proxy'
 $python = 'C:\Users\user\.cache\codex-runtimes\codex-primary-runtime\dependencies\python\python.exe'
-$expectedLiteLLMVersion = '1.90.0'
+$expectedLiteLLMVersion = '1.95.0'
 $launcher = Join-Path $root 'start_litellm_proxy.py'
 $baseConfig = Join-Path $root 'config.yaml'
 $runtimeConfig = Join-Path $root 'config.runtime.yaml'


### PR DESCRIPTION
### What Problem This Solves

Keeps the local Codex LiteLLM proxy on the current stable release and adds an automatic complexity router for cost-aware model selection.

### Why This Change Was Made

LiteLLM 1.95.0 is the current stable PyPI release. The new codex-auto alias delegates prompts across simple, medium, complex, and reasoning tiers while retaining explicit fallbacks.

### User Impact

Local installers now default to LiteLLM 1.95.0. Users can select codex-auto without changing existing aliases.

### Evidence

- 36 targeted router tests passed
- PowerShell parser check passed
- YAML configuration parsed and contains codex-auto
- Python compileall passed
- git diff --check passed
